### PR TITLE
opper-tour: model selector (OpenAI + Gemini) and homepage pre-warm

### DIFF
--- a/examples/opper-tour/public/index.html
+++ b/examples/opper-tour/public/index.html
@@ -140,6 +140,13 @@
         </p>
       </header>
 
+      <div class="text-left mb-3">
+        <label class="block text-xs font-medium mb-1.5" style="color:var(--muted-foreground)">Voice model</label>
+        <select id="modelSelect" class="field w-full px-3 py-2.5 text-sm cursor-pointer">
+          <option value="">Loading…</option>
+        </select>
+      </div>
+
       <button onclick="startSession()" class="btn-primary w-full px-4 py-3 text-sm font-medium">
         Start the tour
       </button>
@@ -242,6 +249,27 @@
     const viewportEmpty = document.getElementById("viewportEmpty");
     const urlBadge = document.getElementById("urlBadge");
     const urlText = document.getElementById("urlText");
+    const modelSelect = document.getElementById("modelSelect");
+
+    // Populate the model dropdown from /api/config. Server is the source
+    // of truth for what's allowed; this just renders the menu.
+    (async function loadConfig() {
+      try {
+        const res = await fetch("/api/config");
+        const cfg = await res.json();
+        modelSelect.innerHTML = "";
+        for (const m of cfg.models) {
+          const o = document.createElement("option");
+          o.value = m.id;
+          o.textContent = m.label;
+          if (m.id === cfg.defaultModel) o.selected = true;
+          modelSelect.appendChild(o);
+        }
+      } catch (err) {
+        console.error("config load failed:", err);
+        modelSelect.innerHTML = '<option value="">(config error)</option>';
+      }
+    })();
 
     // ── Helpers ──────────────────────────────────────────────────────────
     function setStatus(t, live) {
@@ -438,9 +466,15 @@
       messages.innerHTML = "";
       setStatus("Setting up your tour…");
 
+      const chosenModel = modelSelect && modelSelect.value ? modelSelect.value : undefined;
+
       let ticket;
       try {
-        const resp = await fetch("/api/realtime/session", { method: "POST" });
+        const resp = await fetch("/api/realtime/session", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(chosenModel ? { model: chosenModel } : {}),
+        });
         if (!resp.ok) {
           const body = await resp.json().catch(() => ({ error: `mint ${resp.status}` }));
           throw new Error(body.error || `mint ${resp.status}`);

--- a/examples/opper-tour/public/index.html
+++ b/examples/opper-tour/public/index.html
@@ -436,7 +436,7 @@
       landing.classList.add("hidden");
       sessionEl.classList.remove("hidden");
       messages.innerHTML = "";
-      setStatus("Minting ticket…");
+      setStatus("Setting up your tour…");
 
       let ticket;
       try {
@@ -449,10 +449,17 @@
         sessionId = ticket.sessionId;
         console.log("[ticket] minted, sessionId", sessionId, "expires", ticket.expiresAt);
       } catch (err) {
-        setStatus("Failed to mint ticket");
+        setStatus("Failed to start tour");
         addMessage("system", "Could not start the tour: " + err.message);
         return;
       }
+
+      // Pre-warm: the mint endpoint also navigated the server-side Chromium
+      // to opper.ai, so we can paint the homepage in the viewport pane right
+      // away. The agent's instructions are aware of this and greet from the
+      // page rather than calling navigate() on its first turn.
+      if (ticket.initialScreenshot) showScreenshot(ticket.initialScreenshot);
+      if (ticket.initialUrl) showUrl(ticket.initialUrl);
 
       setStatus("Connecting…");
       // Ticket carried in subprotocol header — never in URL, query string,

--- a/examples/opper-tour/server.ts
+++ b/examples/opper-tour/server.ts
@@ -456,8 +456,16 @@ const app = express();
 app.use(express.json({ limit: "1mb" }));
 app.use(express.static(join(__dirname, "public")));
 
-// Mint a ticket + sessionId. The sessionId is *ours*, not Opper's — it
-// keys the BrowserContext we lazy-create on first tool call.
+// Mint a ticket + sessionId, then pre-warm: eagerly open the BrowserContext
+// and navigate it to opper.ai so the viewport pane is already showing the
+// homepage by the time the agent says "hi". The agent's instructions tell
+// it the viewport is loaded, so it greets from there rather than burning
+// its first turn on a navigate().
+//
+// Pre-warm failure is non-fatal — the tour still works with a blank
+// viewport; the agent will navigate on its own when asked.
+const PRE_WARM_URL = "https://opper.ai/";
+
 app.post("/api/realtime/session", async (_req: Request, res: Response) => {
   try {
     const sessionId = randomUUID();
@@ -465,7 +473,21 @@ app.post("/api/realtime/session", async (_req: Request, res: Response) => {
     console.log(
       `  Minted ticket: sessionId=${sessionId.slice(0, 8)}…, expires ${ticket.expiresAt}`,
     );
-    res.json({ ...ticket, sessionId });
+
+    let initialScreenshot: string | undefined;
+    let initialUrl: string | undefined;
+    try {
+      const page = await browserPool.getPage(sessionId);
+      await page.goto(PRE_WARM_URL, { waitUntil: "domcontentloaded", timeout: 15000 });
+      await dismissCookieBanner(page);
+      initialScreenshot = await screenshotJpeg(page);
+      initialUrl = PRE_WARM_URL;
+      console.log(`  Pre-warmed ${PRE_WARM_URL} for ${sessionId.slice(0, 8)}…`);
+    } catch (err) {
+      console.warn(`  Pre-warm failed (session will start blank): ${(err as Error).message}`);
+    }
+
+    res.json({ ...ticket, sessionId, initialScreenshot, initialUrl });
   } catch (err) {
     console.error("  Mint failed:", err);
     res.status(500).json({ error: String(err) });

--- a/examples/opper-tour/server.ts
+++ b/examples/opper-tour/server.ts
@@ -50,11 +50,12 @@ const PUBLIC_WS_BASE =
 // model: append here and update SUPPORTED_MODELS — no other code changes.
 //
 // Note on image input: the `screenshot` tool fires an `image.input` event
-// from the browser to the realtime WS. Per opper-ai/opper#2509 that event
-// is OpenAI-only on first ship; Gemini Live needs a different shape
-// (realtimeInput.video / mediaChunks) and is listed as a follow-up. The
-// `supportsImage` flag lets us mark which models actually receive the
-// screenshot vs. which just see the text tool result.
+// from the browser to the realtime WS. Opper normalizes this across
+// providers — same event name + JSON shape for OpenAI and Gemini Live —
+// and translates to each provider's native wire format underneath. The
+// only Gemini-specific constraint is that `image_url` must be a `data:`
+// URI rather than an `https://` URL, which we already satisfy (the tool
+// produces base64 JPEGs). `supportsImage` marks vision-capable models.
 type ModelEntry = {
   id: string;
   label: string;
@@ -75,7 +76,7 @@ const MODELS: ModelEntry[] = [
     label: "Gemini 3.1 Flash Live",
     defaultVoice: "Aoede",
     supportsReasoningEffort: false,
-    supportsImage: false,
+    supportsImage: true,
   },
 ];
 const DEFAULT_MODEL_ID = MODELS[0].id;

--- a/examples/opper-tour/server.ts
+++ b/examples/opper-tour/server.ts
@@ -44,11 +44,42 @@ const PUBLIC_WS_BASE =
   process.env.OPPER_WS_BASE ||
   OPPER_BASE_URL.replace(/^http/, "ws").replace(/\/$/, "");
 
-// Single-provider for this example. brainstorm-time shows the multi-provider
-// menu pattern; this example keeps the focus on Playwright + screenshot tools.
-const MODEL_ID = "openai/gpt-realtime-2";
-const VOICE = "marin";
-const REASONING_EFFORT = "low";
+// Model menu. brainstorm-time has the full multi-provider pattern with
+// voices + reasoning_effort selectors; opper-tour keeps it simpler — one
+// model picker on the landing page, the model's default voice. To add a
+// model: append here and update SUPPORTED_MODELS — no other code changes.
+//
+// Note on image input: the `screenshot` tool fires an `image.input` event
+// from the browser to the realtime WS. Per opper-ai/opper#2509 that event
+// is OpenAI-only on first ship; Gemini Live needs a different shape
+// (realtimeInput.video / mediaChunks) and is listed as a follow-up. The
+// `supportsImage` flag lets us mark which models actually receive the
+// screenshot vs. which just see the text tool result.
+type ModelEntry = {
+  id: string;
+  label: string;
+  defaultVoice: string;
+  supportsReasoningEffort: boolean;
+  supportsImage: boolean;
+};
+const MODELS: ModelEntry[] = [
+  {
+    id: "openai/gpt-realtime-2",
+    label: "OpenAI GPT Realtime 2",
+    defaultVoice: "marin",
+    supportsReasoningEffort: true,
+    supportsImage: true,
+  },
+  {
+    id: "gemini/gemini-3.1-flash-live-preview",
+    label: "Gemini 3.1 Flash Live",
+    defaultVoice: "Aoede",
+    supportsReasoningEffort: false,
+    supportsImage: false,
+  },
+];
+const DEFAULT_MODEL_ID = MODELS[0].id;
+const DEFAULT_REASONING_EFFORT = "low";
 
 if (!OPPER_API_KEY) {
   console.error("  OPPER_API_KEY is required");
@@ -384,21 +415,25 @@ async function safeScreenshot(page: Page): Promise<string | undefined> {
 // Ticket mint
 // ---------------------------------------------------------------------------
 
-async function mintRealtimeTicket(): Promise<{
+async function mintRealtimeTicket(model: ModelEntry): Promise<{
   clientSecret: string;
   expiresAt: string;
   wsBaseUrl: string;
 }> {
-  const config = {
-    model: MODEL_ID,
+  const config: Record<string, unknown> = {
+    model: model.id,
     instructions: TOUR_INSTRUCTIONS,
-    voice: VOICE,
-    reasoning_effort: REASONING_EFFORT,
+    voice: model.defaultVoice,
     turn_detection: { type: "server_vad", threshold: 0.5, silence_duration_ms: 500 },
     tools: realtimeTools,
     input_transcription: true,
     output_transcription: true,
   };
+  // reasoning_effort is only meaningful on models that advertise it.
+  // Sending it to a model that doesn't accept it gets rejected upstream.
+  if (model.supportsReasoningEffort) {
+    config.reasoning_effort = DEFAULT_REASONING_EFFORT;
+  }
   const body = { config, ttl_seconds: 60 };
 
   const resp = await fetch(`${OPPER_BASE_URL}/v3/realtime-sessions`, {
@@ -466,12 +501,29 @@ app.use(express.static(join(__dirname, "public")));
 // viewport; the agent will navigate on its own when asked.
 const PRE_WARM_URL = "https://opper.ai/";
 
-app.post("/api/realtime/session", async (_req: Request, res: Response) => {
+// Tiny config endpoint so the landing page can render the model dropdown
+// from the same source of truth used at mint time.
+app.get("/api/config", (_req: Request, res: Response) => {
+  res.json({
+    models: MODELS.map((m) => ({ id: m.id, label: m.label })),
+    defaultModel: DEFAULT_MODEL_ID,
+  });
+});
+
+app.post("/api/realtime/session", async (req: Request, res: Response) => {
   try {
     const sessionId = randomUUID();
-    const ticket = await mintRealtimeTicket();
+    const requestedModel = (req.body?.model as string | undefined) || DEFAULT_MODEL_ID;
+    const model = MODELS.find((m) => m.id === requestedModel);
+    if (!model) {
+      return res.status(400).json({
+        error: `model "${requestedModel}" not in allowlist`,
+        allowed: MODELS.map((m) => m.id),
+      });
+    }
+    const ticket = await mintRealtimeTicket(model);
     console.log(
-      `  Minted ticket: sessionId=${sessionId.slice(0, 8)}…, expires ${ticket.expiresAt}`,
+      `  Minted ticket: model=${model.id}, sessionId=${sessionId.slice(0, 8)}…, expires ${ticket.expiresAt}`,
     );
 
     let initialScreenshot: string | undefined;

--- a/examples/opper-tour/tour-knowledge.ts
+++ b/examples/opper-tour/tour-knowledge.ts
@@ -161,6 +161,13 @@ ${SITE_MAP_FOR_PROMPT}
 
 Anything under opper.ai, docs.opper.ai, or github.com/opper-ai is fair game. Anywhere else returns a "not allowed" error — explain the limit honestly and offer the closest match from the site map.
 
+--- WHEN THE SESSION STARTS ---
+The viewport pane already shows https://opper.ai/ — the user can see the Opper homepage right now. **Do NOT call navigate() as your first move; the page is already loaded.** Your opening turn is:
+1. Greet the user warmly in one short sentence (e.g. "Hey — welcome to a quick tour of Opper.").
+2. Say what they're looking at — the Opper homepage, "the AI gateway for agents", and mention they can sign in from the top-right.
+3. Ask what they'd like to see first — pricing, the model directory, the docs, something else.
+Only call navigate() once the user has picked a destination.
+
 --- YOUR TOOLS ---
 Each tool runs against a real headless Chromium that the user watches via a screenshot pane. After every action, a fresh screenshot lands on the user's screen.
 


### PR DESCRIPTION
## Summary

Three follow-ups on top of the Phase 0.5 merge (#9):

- **Pre-warm the BrowserContext to opper.ai at ticket-mint time** so the viewport pane shows the homepage from the first second instead of going blank until the agent's first `navigate()` call. The system prompt is updated to greet from the homepage rather than open with a navigation.
- **Model selector on the landing page** — choose between OpenAI GPT Realtime 2 (default) and Gemini 3.1 Flash Live before starting the tour. Server exposes `GET /api/config` to drive the dropdown, validates the chosen model at mint time, and only sends `reasoning_effort` to models that advertise support. Adding a third model is one entry in `MODELS[]` with no other code changes.
- **Gemini vision is on the same wire shape as OpenAI** — Opper's realtime layer normalizes `image.input` across providers, so the `screenshot` tool already works on Gemini (it already emits a `data:` URI, which is the only Gemini-specific constraint). `supportsImage` flag and comment updated to reflect this.

## Test plan

- [x] `GET /api/config` returns both models with `defaultModel`
- [x] `POST /api/realtime/session` (no body) mints with OpenAI default
- [x] `POST /api/realtime/session` with `{ model: "gemini/gemini-3.1-flash-live-preview" }` mints with Gemini
- [x] Bogus model returns `400 { error, allowed[] }`
- [x] Both mints log `Pre-warmed https://opper.ai/ for …` and return `initialUrl` + `initialScreenshot`
- [x] End-to-end with mic in browser, OpenAI: tour navigates, screenshot tool sends image to model
- [x] End-to-end with mic in browser, Gemini: same, including image input working