### PR TITLE
Add server-tools-compare example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Examples and guides for building with [Opper](https://opper.ai). PRs are welcome
 | [chatbot-openresponses](examples/chatbot-openresponses/) | TypeScript | OpenResponses endpoint via raw fetch(), agentic tool loop, image generation, TTS, web UI |
 | [brainstorm-time](examples/brainstorm-time/) | TypeScript | Realtime voice brainstorming — browser-direct WebSocket via ephemeral tickets, mic input, image generation, web search, live idea board |
 | [opper-tour](examples/opper-tour/) | TypeScript | Realtime voice tour guide that drives a server-side Playwright Chromium and streams screenshots back to the browser — pre-baked Opper site map, URL allowlist, per-session BrowserContext |
+| [server-tools-compare](examples/server-tools-compare/) | TypeScript | Side-by-side web search: same question fanned out to Anthropic, OpenAI, and Google server-side tools through Opper compat — answer, cost, latency per provider |
 | [login-with-opper-web](examples/login-with-opper-web/) | JavaScript | OAuth login flow, token exchange, inference — Express web app with branded button |
 | [login-with-opper-cli](examples/login-with-opper-cli/) | JavaScript | Device Authorization Flow for CLI apps — code-based login, polling, inference |
 

--- a/examples/server-tools-compare/README.md
+++ b/examples/server-tools-compare/README.md
@@ -1,0 +1,48 @@
+# server-tools-compare
+
+Side-by-side comparison of Anthropic, OpenAI, and Google **server-side web search** through Opper's compat endpoints.
+
+One question gets fanned out to three providers in parallel; each provider runs its own search internally (no client-side tool round trip) and returns a final answer. The UI shows answer, latency, and Opper-reported cost per provider — making it easy to see how each provider trades off speed, citation style, and price on the same query.
+
+## What this demonstrates
+
+- **Server-side tools across all three providers** on a single API key
+  - Anthropic `web_search_20250305` → `POST /v3/compat/v1/messages`
+  - OpenAI `web_search` → `POST /v3/compat/responses`
+  - Google `googleSearch` → `POST /v3/compat/v1beta/models/{model}:generateContent`
+- **No tool-result round trip** — the model invokes the tool, the provider runs it, you get the answer back in one response
+- **Surcharge billing** surfaced live via the `X-Opper-Cost` response header — token cost plus the per-provider server-tool surcharge (e.g. $0.01/search for Anthropic web_search, $0.035/prompt for Google grounding)
+- **Citation styles** — each provider cites sources inline as markdown links the UI renders
+
+## Run
+
+```bash
+cd examples/server-tools-compare
+npm install
+export OPPER_API_KEY=sk-op-...
+npm start
+```
+
+Open http://localhost:3000.
+
+### Environment
+
+| Var | Default | What it does |
+| --- | --- | --- |
+| `OPPER_API_KEY` | (required) | Opper key — get one at https://opper.ai |
+| `OPPER_BASE_URL` | `https://api.opper.ai` | Override for staging / local stack |
+| `ANTHROPIC_MODEL` | `anthropic/claude-sonnet-4-5` | Any Claude model with `web_search_*` support |
+| `OPENAI_MODEL` | `openai/gpt-5` | Any OpenAI model with Responses API support |
+| `GOOGLE_MODEL` | `gemini-2.5-flash` | Any Gemini model with grounding support |
+
+## How it works
+
+`server.ts` has three short adapter functions — one per provider — each making a single `fetch` to the corresponding compat endpoint. Request bodies use the provider's native shape; Opper forwards them verbatim. Each adapter pulls answer text out of the provider-specific response envelope (`content[].text` for Anthropic, `output_text` for OpenAI, `candidates[].content.parts[].text` for Google) and reads the `X-Opper-Cost` response header for billed cost.
+
+The frontend is a single HTML page that POSTs the question to `/api/ask` and renders the three providers in a grid. Inline markdown link citations from each provider get rendered as clickable links.
+
+## Notes
+
+- The cost shown is what Opper bills you per request — token cost plus the provider-specific server-tool surcharge.
+- If you don't have access to a particular provider on your Opper key, that column will show the upstream error inline; the other two still work.
+- Opper's compat layer normalizes the response envelope and drops some of the structured server-tool metadata (e.g. Anthropic's `web_search_tool_result` blocks, Google's `groundingChunks`). What you see in this demo is what a typical compat-API consumer gets back.

--- a/examples/server-tools-compare/README.md
+++ b/examples/server-tools-compare/README.md
@@ -2,7 +2,7 @@
 
 Side-by-side comparison of Anthropic, OpenAI, and Google **server-side web search** through Opper's compat endpoints.
 
-One question gets fanned out to three providers in parallel; each provider runs its own search internally (no client-side tool round trip) and returns a final answer. The UI shows answer, latency, and Opper-reported cost per provider — making it easy to see how each provider trades off speed, citation style, and price on the same query.
+One question gets fanned out to three providers in parallel; each provider runs its own search internally (no client-side tool round trip) and returns the final answer plus the actual search queries it issued and citation URLs for every source it grounded on. The UI shows answer, queries, citations, latency, cost, and response size per provider.
 
 ## What this demonstrates
 
@@ -11,8 +11,9 @@ One question gets fanned out to three providers in parallel; each provider runs 
   - OpenAI `web_search` → `POST /v3/compat/responses`
   - Google `googleSearch` → `POST /v3/compat/v1beta/models/{model}:generateContent`
 - **No tool-result round trip** — the model invokes the tool, the provider runs it, you get the answer back in one response
+- **Full provider-native response fidelity** — every endpoint round-trips its provider's server-tool blocks verbatim (Anthropic `server_tool_use` + `web_search_tool_result` + text `citations[]`; OpenAI `web_search_call` + `url_citation` annotations; Google `groundingMetadata`)
 - **Surcharge billing** surfaced live via the `X-Opper-Cost` response header — token cost plus the per-provider server-tool surcharge (e.g. $0.01/search for Anthropic web_search, $0.035/prompt for Google grounding)
-- **Citation styles** — each provider cites sources inline as markdown links the UI renders
+- **Compact-response toggle** — flip the checkbox to enable `X-Opper-Compact-Response: true` and watch the Anthropic response shrink ~90% (encrypted_content stripped, citation URLs preserved). Tradeoff documented inline.
 
 ## Run
 
@@ -37,12 +38,18 @@ Open http://localhost:3000.
 
 ## How it works
 
-`server.ts` has three short adapter functions — one per provider — each making a single `fetch` to the corresponding compat endpoint. Request bodies use the provider's native shape; Opper forwards them verbatim. Each adapter pulls answer text out of the provider-specific response envelope (`content[].text` for Anthropic, `output_text` for OpenAI, `candidates[].content.parts[].text` for Google) and reads the `X-Opper-Cost` response header for billed cost.
+`server.ts` has three short adapter functions — one per provider — each making a single `fetch` to the corresponding compat endpoint. Request bodies use the provider's native shape; Opper forwards them verbatim. Each adapter walks the provider-specific response envelope to pull out:
 
-The frontend is a single HTML page that POSTs the question to `/api/ask` and renders the three providers in a grid. Inline markdown link citations from each provider get rendered as clickable links.
+- **Answer text** — `content[].text` for Anthropic, `output_text` for OpenAI, `candidates[].content.parts[].text` for Google
+- **Queries** — `server_tool_use.input.query` for Anthropic, `web_search_call.action.queries[]` for OpenAI, `groundingMetadata.webSearchQueries[]` for Google
+- **Citations** — text-block `citations[]` for Anthropic, `output_text.annotations[]` (url_citation) for OpenAI, `groundingMetadata.groundingChunks[].web` for Google
+- **Cost** — `X-Opper-Cost` response header (the same Opper-billed cost in all three cases)
+
+The frontend is a single HTML page that POSTs the question to `/api/ask`, then renders the three providers in a grid with skeleton loaders while requests run. A checkbox toggles the `X-Opper-Compact-Response: true` header on or off so you can see the response size difference live.
 
 ## Notes
 
 - The cost shown is what Opper bills you per request — token cost plus the provider-specific server-tool surcharge.
 - If you don't have access to a particular provider on your Opper key, that column will show the upstream error inline; the other two still work.
-- Opper's compat layer normalizes the response envelope and drops some of the structured server-tool metadata (e.g. Anthropic's `web_search_tool_result` blocks, Google's `groundingChunks`). What you see in this demo is what a typical compat-API consumer gets back.
+- In **compact mode**, Google's `groundingChunks` keep titles but drop the (long signed redirect) URIs — those citations render as plain text since there's nothing to link to. Anthropic compact strips `encrypted_content` from search results but preserves the citation URLs.
+- Compact-mode responses **cannot be replayed in multi-turn conversation** to extend a cited turn, because Anthropic's citation continuity needs the `encrypted_content` / `encrypted_index` blobs that compact mode strips. That's the documented contract.

--- a/examples/server-tools-compare/package.json
+++ b/examples/server-tools-compare/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "server-tools-compare",
+  "version": "0.1.0",
+  "description": "Side-by-side comparison of Anthropic / OpenAI / Google server-side web search through Opper compat endpoints",
+  "type": "module",
+  "scripts": {
+    "start": "tsx server.ts"
+  },
+  "dependencies": {
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "tsx": "^4.0.0"
+  }
+}

--- a/examples/server-tools-compare/public/index.html
+++ b/examples/server-tools-compare/public/index.html
@@ -69,6 +69,7 @@
       background: var(--card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
+      display: flex; flex-direction: column;
     }
     .col-header {
       display: flex; align-items: center; gap: 8px;
@@ -88,12 +89,47 @@
       text-decoration-color: var(--border);
     }
     .col-body a:hover { text-decoration-color: var(--foreground); }
+    .col-section {
+      padding: 10px 14px;
+      border-top: 1px solid var(--border);
+      font-size: 12px;
+    }
+    .col-section-label {
+      font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;
+      color: var(--muted-foreground); margin-bottom: 6px;
+    }
+    .queries { display: flex; flex-wrap: wrap; gap: 4px; }
+    .query-chip {
+      background: var(--muted);
+      border-radius: 999px;
+      padding: 3px 9px;
+      font-size: 12px;
+      color: var(--foreground);
+    }
+    .citations { display: flex; flex-direction: column; gap: 6px; }
+    .citation {
+      display: flex; flex-direction: column; gap: 2px;
+      background: var(--muted);
+      border-radius: 6px;
+      padding: 6px 9px;
+    }
+    .citation a {
+      color: var(--foreground); font-size: 12px;
+      text-decoration: none;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .citation a:hover { text-decoration: underline; }
+    .citation-host {
+      font-size: 10px; color: var(--muted-foreground);
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
     .col-meta {
       padding: 10px 14px;
       border-top: 1px solid var(--border);
       display: flex; gap: 14px; flex-wrap: wrap;
       font-size: 12px;
       color: var(--muted-foreground);
+      margin-top: auto;
     }
     .col-meta b { color: var(--foreground); font-weight: 600; }
     .error {
@@ -121,6 +157,13 @@
       0% { background-position: 200% 0; }
       100% { background-position: -200% 0; }
     }
+    .toggle {
+      display: inline-flex; align-items: center; gap: 8px;
+      font-size: 12px; color: var(--muted-foreground);
+      cursor: pointer;
+      user-select: none;
+    }
+    .toggle input { accent-color: var(--foreground); }
   </style>
 </head>
 <body>
@@ -132,7 +175,7 @@
       </p>
     </header>
 
-    <form id="ask-form" class="mb-6 flex gap-2">
+    <form id="ask-form" class="mb-3 flex gap-2">
       <input
         id="question"
         type="text"
@@ -143,11 +186,17 @@
       <button id="ask" type="submit" class="btn-primary px-6 py-3 text-sm font-semibold">Ask</button>
     </form>
 
-    <div class="mb-6 flex flex-wrap gap-2" id="examples">
-      <button class="btn-ghost" data-q="Who is the current president of the United States?">US president?</button>
-      <button class="btn-ghost" data-q="Who won the most recent F1 race?">Most recent F1 winner</button>
-      <button class="btn-ghost" data-q="What's the latest news about Anthropic's Claude models?">Latest Claude news</button>
-      <button class="btn-ghost" data-q="What was the top tech headline today?">Top tech headline today</button>
+    <div class="mb-6 flex items-center justify-between flex-wrap gap-3">
+      <div class="flex flex-wrap gap-2" id="examples">
+        <button class="btn-ghost" data-q="Who is the current president of the United States?">US president?</button>
+        <button class="btn-ghost" data-q="Who won the most recent F1 race?">Most recent F1 winner</button>
+        <button class="btn-ghost" data-q="What's the latest news about Anthropic's Claude models?">Latest Claude news</button>
+        <button class="btn-ghost" data-q="What was the top tech headline today?">Top tech headline today</button>
+      </div>
+      <label class="toggle" title="Strip bandwidth-heavy payloads (search snippets, encrypted_content) but keep citation URLs">
+        <input type="checkbox" id="compact" />
+        <span>Compact response (<code>X-Opper-Compact-Response</code>)</span>
+      </label>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4" id="results">
@@ -158,6 +207,14 @@
           <span class="text-xs font-normal" style="color: var(--muted-foreground)">claude-sonnet-4-5</span>
         </div>
         <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
+        <div class="col-section" data-slot="queries-section" hidden>
+          <div class="col-section-label">Queries</div>
+          <div class="queries" data-slot="queries"></div>
+        </div>
+        <div class="col-section" data-slot="citations-section" hidden>
+          <div class="col-section-label">Citations</div>
+          <div class="citations" data-slot="citations"></div>
+        </div>
         <div class="col-meta" data-slot="meta"></div>
       </section>
 
@@ -168,6 +225,14 @@
           <span class="text-xs font-normal" style="color: var(--muted-foreground)">gpt-5</span>
         </div>
         <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
+        <div class="col-section" data-slot="queries-section" hidden>
+          <div class="col-section-label">Queries</div>
+          <div class="queries" data-slot="queries"></div>
+        </div>
+        <div class="col-section" data-slot="citations-section" hidden>
+          <div class="col-section-label">Citations</div>
+          <div class="citations" data-slot="citations"></div>
+        </div>
         <div class="col-meta" data-slot="meta"></div>
       </section>
 
@@ -178,6 +243,14 @@
           <span class="text-xs font-normal" style="color: var(--muted-foreground)">gemini-2.5-flash</span>
         </div>
         <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
+        <div class="col-section" data-slot="queries-section" hidden>
+          <div class="col-section-label">Queries</div>
+          <div class="queries" data-slot="queries"></div>
+        </div>
+        <div class="col-section" data-slot="citations-section" hidden>
+          <div class="col-section-label">Citations</div>
+          <div class="citations" data-slot="citations"></div>
+        </div>
         <div class="col-meta" data-slot="meta"></div>
       </section>
     </div>
@@ -187,6 +260,7 @@
     const form = document.getElementById('ask-form');
     const input = document.getElementById('question');
     const askBtn = document.getElementById('ask');
+    const compactToggle = document.getElementById('compact');
 
     document.getElementById('examples').addEventListener('click', (e) => {
       const btn = e.target.closest('button[data-q]');
@@ -204,7 +278,7 @@
         const res = await fetch('/api/ask', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ question: q }),
+          body: JSON.stringify({ question: q, compact: compactToggle.checked }),
         });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || 'request failed');
@@ -213,7 +287,7 @@
         renderProvider('google', data.google);
       } catch (err) {
         for (const p of ['anthropic', 'openai', 'google']) {
-          renderProvider(p, { error: err.message, answer: '', citations: [], searches: 0, cost: null, ms: 0 });
+          renderProvider(p, { error: err.message });
         }
       } finally {
         setLoading(false);
@@ -232,6 +306,8 @@
             <div class="skeleton-line" style="width: 75%"></div>
             <div class="skeleton-line" style="width: 60%"></div>
           </div>`;
+        section.querySelector('[data-slot="queries-section"]').hidden = true;
+        section.querySelector('[data-slot="citations-section"]').hidden = true;
         section.querySelector('[data-slot="meta"]').innerHTML =
           '<span class="pulse"></span> running web_search&hellip;';
       }
@@ -241,17 +317,51 @@
       const section = document.querySelector(`[data-provider="${name}"]`);
       const answer = section.querySelector('[data-slot="answer"]');
       const meta = section.querySelector('[data-slot="meta"]');
+      const qSection = section.querySelector('[data-slot="queries-section"]');
+      const qList = section.querySelector('[data-slot="queries"]');
+      const cSection = section.querySelector('[data-slot="citations-section"]');
+      const cList = section.querySelector('[data-slot="citations"]');
 
       if (r.error) {
         answer.innerHTML = '';
+        qSection.hidden = true;
+        cSection.hidden = true;
         meta.innerHTML = `<div class="error">${escapeHtml(r.error)}</div>`;
         return;
       }
 
       answer.innerHTML = renderAnswer(r.answer || '(no text returned)');
+
+      const queries = r.queries || [];
+      if (queries.length) {
+        qSection.hidden = false;
+        qList.innerHTML = queries.map(q => `<span class="query-chip">${escapeHtml(q)}</span>`).join('');
+      } else {
+        qSection.hidden = true;
+      }
+
+      const citations = r.citations || [];
+      if (citations.length) {
+        cSection.hidden = false;
+        cList.innerHTML = citations.slice(0, 8).map(c => {
+          // Compact mode strips Google groundingChunk URIs (titles preserved);
+          // render those as plain text since there's nothing to link to.
+          const titleHtml = c.url
+            ? `<a href="${escapeAttr(c.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(c.title)}</a>`
+            : escapeHtml(c.title);
+          const host = c.url ? `<div class="citation-host">${escapeHtml(hostOf(c.url))}</div>` : '';
+          return `<div class="citation">${titleHtml}${host}</div>`;
+        }).join('');
+      } else {
+        cSection.hidden = true;
+      }
+
       meta.innerHTML = [
+        `<span><b>${queries.length}</b> search${queries.length === 1 ? '' : 'es'}</span>`,
+        `<span><b>${citations.length}</b> citation${citations.length === 1 ? '' : 's'}</span>`,
         `<span><b>${(r.ms / 1000).toFixed(1)}s</b></span>`,
         r.cost != null ? `<span><b>$${r.cost.toFixed(5)}</b></span>` : '',
+        `<span><b>${formatBytes(r.bytes)}</b></span>`,
       ].filter(Boolean).join('');
     }
 
@@ -262,6 +372,17 @@
       return escaped.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, (_, title, url) =>
         `<a href="${escapeAttr(url)}" target="_blank" rel="noopener noreferrer">${title}</a>`
       );
+    }
+
+    function hostOf(url) {
+      try { return new URL(url).host; } catch { return url; }
+    }
+
+    function formatBytes(n) {
+      if (n == null) return '';
+      if (n < 1024) return `${n} B`;
+      if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+      return `${(n / 1024 / 1024).toFixed(2)} MB`;
     }
 
     function escapeHtml(s) {

--- a/examples/server-tools-compare/public/index.html
+++ b/examples/server-tools-compare/public/index.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Server-side tools compare</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Wix+Madefor+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --background: oklch(1 0 0);
+      --foreground: oklch(0.2938 0.0414 248.11);
+      --card: oklch(1 0 0);
+      --muted: oklch(0.97 0 0);
+      --muted-foreground: oklch(0.45 0 0);
+      --border: oklch(0.922 0 0);
+      --primary: oklch(0.205 0 0);
+      --primary-foreground: oklch(0.985 0 0);
+      --ring: oklch(0.708 0 0);
+      --radius: 0.625rem;
+      --anthropic: oklch(0.62 0.16 35);
+      --openai: oklch(0.55 0.13 165);
+      --google: oklch(0.6 0.15 250);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --background: oklch(0.252 0 102.07);
+        --foreground: oklch(0.9881 0 102.07);
+        --card: oklch(0.23 0 0);
+        --muted: oklch(0.30 0 0);
+        --muted-foreground: oklch(0.72 0 0);
+        --border: oklch(0.35 0 0);
+        --primary: oklch(0.9881 0 102.07);
+        --primary-foreground: oklch(0.252 0 102.07);
+        --ring: oklch(0.556 0 0);
+      }
+    }
+    html, body { background: var(--background); color: var(--foreground); }
+    body { font-family: 'Wix Madefor Display', system-ui, -apple-system, sans-serif; }
+    .field {
+      background: var(--card);
+      color: var(--foreground);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .field:hover { border-color: oklch(from var(--border) calc(l - 0.05) c h); }
+    .field:focus-visible { outline: none; border-color: var(--ring); box-shadow: 0 0 0 3px oklch(from var(--ring) l c h / 0.25); }
+    .btn-primary {
+      background: var(--primary);
+      color: var(--primary-foreground);
+      border-radius: var(--radius);
+      transition: opacity 150ms ease, transform 80ms ease;
+    }
+    .btn-primary:hover { opacity: 0.9; }
+    .btn-primary:active { transform: translateY(1px); }
+    .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-ghost {
+      background: var(--muted);
+      color: var(--muted-foreground);
+      border-radius: var(--radius);
+      transition: background-color 150ms ease, color 150ms ease;
+      font-size: 12px;
+      padding: 4px 10px;
+    }
+    .btn-ghost:hover { color: var(--foreground); }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+    }
+    .col-header {
+      display: flex; align-items: center; gap: 8px;
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--border);
+      font-weight: 600; font-size: 13px;
+    }
+    .col-swatch { width: 8px; height: 8px; border-radius: 2px; }
+    .col-body {
+      padding: 14px;
+      font-size: 14px; line-height: 1.55;
+      white-space: pre-wrap;
+      min-height: 80px;
+    }
+    .col-body a {
+      color: var(--foreground); text-decoration: underline; text-underline-offset: 2px;
+      text-decoration-color: var(--border);
+    }
+    .col-body a:hover { text-decoration-color: var(--foreground); }
+    .col-meta {
+      padding: 10px 14px;
+      border-top: 1px solid var(--border);
+      display: flex; gap: 14px; flex-wrap: wrap;
+      font-size: 12px;
+      color: var(--muted-foreground);
+    }
+    .col-meta b { color: var(--foreground); font-weight: 600; }
+    .error {
+      padding: 14px;
+      font-size: 13px; color: oklch(0.55 0.18 25);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+    .pulse {
+      display: inline-block;
+      width: 8px; height: 8px; border-radius: 999px;
+      background: var(--muted-foreground);
+      animation: pulse 1.2s ease-in-out infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 0.3; }
+      50% { opacity: 1; }
+    }
+    .skeleton-line {
+      height: 12px; border-radius: 4px;
+      background: linear-gradient(90deg, var(--muted) 0%, oklch(from var(--muted) calc(l + 0.04) c h) 50%, var(--muted) 100%);
+      background-size: 200% 100%;
+      animation: shimmer 1.2s ease-in-out infinite;
+    }
+    @keyframes shimmer {
+      0% { background-position: 200% 0; }
+      100% { background-position: -200% 0; }
+    }
+  </style>
+</head>
+<body>
+  <div class="max-w-6xl mx-auto px-6 py-10">
+    <header class="mb-8">
+      <h1 class="text-3xl font-semibold mb-2">Server-side tools, side by side</h1>
+      <p class="text-sm" style="color: var(--muted-foreground); max-width: 64ch;">
+        One question, fanned out to Anthropic <code>web_search</code>, OpenAI <code>web_search</code>, and Google <code>googleSearch</code> through Opper's compat endpoints in parallel. No client-side tool loop &mdash; each provider runs its own search and returns the final answer plus citations.
+      </p>
+    </header>
+
+    <form id="ask-form" class="mb-6 flex gap-2">
+      <input
+        id="question"
+        type="text"
+        class="field flex-1 px-4 py-3 text-base"
+        placeholder="Ask anything that needs fresh info&hellip; e.g. 'Who won the most recent F1 race?'"
+        autocomplete="off"
+      />
+      <button id="ask" type="submit" class="btn-primary px-6 py-3 text-sm font-semibold">Ask</button>
+    </form>
+
+    <div class="mb-6 flex flex-wrap gap-2" id="examples">
+      <button class="btn-ghost" data-q="Who is the current president of the United States?">US president?</button>
+      <button class="btn-ghost" data-q="Who won the most recent F1 race?">Most recent F1 winner</button>
+      <button class="btn-ghost" data-q="What's the latest news about Anthropic's Claude models?">Latest Claude news</button>
+      <button class="btn-ghost" data-q="What was the top tech headline today?">Top tech headline today</button>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4" id="results">
+      <section class="card" data-provider="anthropic">
+        <div class="col-header">
+          <span class="col-swatch" style="background: var(--anthropic)"></span>
+          Anthropic
+          <span class="text-xs font-normal" style="color: var(--muted-foreground)">claude-sonnet-4-5</span>
+        </div>
+        <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
+        <div class="col-meta" data-slot="meta"></div>
+      </section>
+
+      <section class="card" data-provider="openai">
+        <div class="col-header">
+          <span class="col-swatch" style="background: var(--openai)"></span>
+          OpenAI
+          <span class="text-xs font-normal" style="color: var(--muted-foreground)">gpt-5</span>
+        </div>
+        <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
+        <div class="col-meta" data-slot="meta"></div>
+      </section>
+
+      <section class="card" data-provider="google">
+        <div class="col-header">
+          <span class="col-swatch" style="background: var(--google)"></span>
+          Google
+          <span class="text-xs font-normal" style="color: var(--muted-foreground)">gemini-2.5-flash</span>
+        </div>
+        <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
+        <div class="col-meta" data-slot="meta"></div>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    const form = document.getElementById('ask-form');
+    const input = document.getElementById('question');
+    const askBtn = document.getElementById('ask');
+
+    document.getElementById('examples').addEventListener('click', (e) => {
+      const btn = e.target.closest('button[data-q]');
+      if (!btn) return;
+      input.value = btn.dataset.q;
+      form.requestSubmit();
+    });
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const q = input.value.trim();
+      if (!q) return;
+      setLoading(true);
+      try {
+        const res = await fetch('/api/ask', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ question: q }),
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || 'request failed');
+        renderProvider('anthropic', data.anthropic);
+        renderProvider('openai', data.openai);
+        renderProvider('google', data.google);
+      } catch (err) {
+        for (const p of ['anthropic', 'openai', 'google']) {
+          renderProvider(p, { error: err.message, answer: '', citations: [], searches: 0, cost: null, ms: 0 });
+        }
+      } finally {
+        setLoading(false);
+      }
+    });
+
+    function setLoading(on) {
+      askBtn.disabled = on;
+      askBtn.textContent = on ? 'Asking…' : 'Ask';
+      if (!on) return;
+      for (const p of ['anthropic', 'openai', 'google']) {
+        const section = document.querySelector(`[data-provider="${p}"]`);
+        section.querySelector('[data-slot="answer"]').innerHTML = `
+          <div class="flex flex-col gap-2">
+            <div class="skeleton-line" style="width: 90%"></div>
+            <div class="skeleton-line" style="width: 75%"></div>
+            <div class="skeleton-line" style="width: 60%"></div>
+          </div>`;
+        section.querySelector('[data-slot="meta"]').innerHTML =
+          '<span class="pulse"></span> running web_search&hellip;';
+      }
+    }
+
+    function renderProvider(name, r) {
+      const section = document.querySelector(`[data-provider="${name}"]`);
+      const answer = section.querySelector('[data-slot="answer"]');
+      const meta = section.querySelector('[data-slot="meta"]');
+
+      if (r.error) {
+        answer.innerHTML = '';
+        meta.innerHTML = `<div class="error">${escapeHtml(r.error)}</div>`;
+        return;
+      }
+
+      answer.innerHTML = renderAnswer(r.answer || '(no text returned)');
+      meta.innerHTML = [
+        `<span><b>${(r.ms / 1000).toFixed(1)}s</b></span>`,
+        r.cost != null ? `<span><b>$${r.cost.toFixed(5)}</b></span>` : '',
+      ].filter(Boolean).join('');
+    }
+
+    // Light markdown-link rendering — providers cite sources inline as
+    // [title](url). Everything else stays as plain text.
+    function renderAnswer(s) {
+      const escaped = escapeHtml(s);
+      return escaped.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, (_, title, url) =>
+        `<a href="${escapeAttr(url)}" target="_blank" rel="noopener noreferrer">${title}</a>`
+      );
+    }
+
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>"']/g, c => ({
+        '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
+      }[c]));
+    }
+    function escapeAttr(s) { return escapeHtml(s); }
+  </script>
+</body>
+</html>

--- a/examples/server-tools-compare/public/index.html
+++ b/examples/server-tools-compare/public/index.html
@@ -274,21 +274,26 @@
       const q = input.value.trim();
       if (!q) return;
       setLoading(true);
-      try {
-        const res = await fetch('/api/ask', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ question: q, compact: compactToggle.checked }),
-        });
-        const data = await res.json();
-        if (!res.ok) throw new Error(data.error || 'request failed');
-        renderProvider('anthropic', data.anthropic);
-        renderProvider('openai', data.openai);
-        renderProvider('google', data.google);
-      } catch (err) {
-        for (const p of ['anthropic', 'openai', 'google']) {
-          renderProvider(p, { error: err.message });
+      const payload = JSON.stringify({ question: q, compact: compactToggle.checked });
+      // Fan out: three independent requests; each column paints as soon
+      // as its provider finishes, so the fast one (often Google ~2s) shows
+      // up without waiting for the slow one (often OpenAI ~20s).
+      const tasks = ['anthropic', 'openai', 'google'].map(async (provider) => {
+        try {
+          const res = await fetch(`/api/ask/${provider}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: payload,
+          });
+          const data = await res.json();
+          if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+          renderProvider(provider, data);
+        } catch (err) {
+          renderProvider(provider, { error: err.message });
         }
+      });
+      try {
+        await Promise.all(tasks);
       } finally {
         setLoading(false);
       }

--- a/examples/server-tools-compare/server.ts
+++ b/examples/server-tools-compare/server.ts
@@ -1,0 +1,190 @@
+/**
+ * Server-tools compare: fans the same question out to Anthropic, OpenAI,
+ * and Google server-side web search through Opper's compat endpoints,
+ * then returns the three answers + citations + costs side by side.
+ *
+ * Each provider runs its tool internally — no client-side round trip —
+ * so this is a tight demo of what server-side tools actually buy you
+ * vs the function-tool pattern.
+ */
+
+import express from "express";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { createServer } from "net";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const PREFERRED_PORT = parseInt(process.env.PORT || "3000");
+const OPPER_API_KEY = process.env.OPPER_API_KEY;
+const OPPER_BASE_URL = process.env.OPPER_BASE_URL || "https://api.opper.ai";
+
+if (!OPPER_API_KEY) {
+  console.error("OPPER_API_KEY is required");
+  process.exit(1);
+}
+
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || "anthropic/claude-sonnet-4-5";
+const OPENAI_MODEL = process.env.OPENAI_MODEL || "openai/gpt-5";
+const GOOGLE_MODEL = process.env.GOOGLE_MODEL || "gemini-2.5-flash";
+
+async function findPort(start: number, end = start + 20): Promise<number> {
+  for (let port = start; port <= end; port++) {
+    const available = await new Promise<boolean>((resolve) => {
+      const srv = createServer();
+      srv.once("error", () => resolve(false));
+      srv.listen(port, () => { srv.close(() => resolve(true)); });
+    });
+    if (available) return port;
+  }
+  return start;
+}
+
+// ---------------------------------------------------------------------------
+// Response shape returned to the browser
+// ---------------------------------------------------------------------------
+
+interface ProviderResult {
+  answer: string;
+  cost: number | null;       // dollars, from X-Opper-Cost
+  ms: number;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic — POST /v3/compat/v1/messages with web_search_20250305
+// ---------------------------------------------------------------------------
+
+async function askAnthropic(question: string): Promise<ProviderResult> {
+  const started = Date.now();
+  try {
+    const res = await fetch(`${OPPER_BASE_URL}/v3/compat/v1/messages`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${OPPER_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: ANTHROPIC_MODEL,
+        max_tokens: 1024,
+        messages: [{ role: "user", content: question }],
+        tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 3 }],
+      }),
+    });
+    const cost = parseCostHeader(res.headers);
+    const body = await res.json() as any;
+    if (!res.ok) throw new Error(body?.error?.message || `HTTP ${res.status}`);
+
+    const answer = (body.content || [])
+      .filter((b: any) => b.type === "text")
+      .map((b: any) => b.text)
+      .join("");
+    return { answer, cost, ms: Date.now() - started };
+  } catch (err: any) {
+    return { answer: "", cost: null, ms: Date.now() - started, error: err.message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI — POST /v3/compat/responses with {type:"web_search"}
+// ---------------------------------------------------------------------------
+
+async function askOpenAI(question: string): Promise<ProviderResult> {
+  const started = Date.now();
+  try {
+    const res = await fetch(`${OPPER_BASE_URL}/v3/compat/responses`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${OPPER_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        input: question,
+        tools: [{ type: "web_search" }],
+      }),
+    });
+    const cost = parseCostHeader(res.headers);
+    const body = await res.json() as any;
+    if (!res.ok) throw new Error(body?.error?.message || `HTTP ${res.status}`);
+
+    const answer = body.output_text
+      || (body.output || [])
+        .flatMap((item: any) => item.type === "message" ? (item.content || []) : [])
+        .filter((p: any) => p.type === "output_text")
+        .map((p: any) => p.text || "")
+        .join("");
+    return { answer, cost, ms: Date.now() - started };
+  } catch (err: any) {
+    return { answer: "", cost: null, ms: Date.now() - started, error: err.message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Google — POST /v3/compat/v1beta/models/{model}:generateContent with googleSearch
+// ---------------------------------------------------------------------------
+
+async function askGoogle(question: string): Promise<ProviderResult> {
+  const started = Date.now();
+  try {
+    const url = `${OPPER_BASE_URL}/v3/compat/v1beta/models/${encodeURIComponent(GOOGLE_MODEL)}:generateContent`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${OPPER_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        contents: [{ role: "user", parts: [{ text: question }] }],
+        tools: [{ googleSearch: {} }],
+      }),
+    });
+    const cost = parseCostHeader(res.headers);
+    const body = await res.json() as any;
+    if (!res.ok) throw new Error(body?.error?.message || `HTTP ${res.status}`);
+
+    const answer = (body.candidates?.[0]?.content?.parts || [])
+      .map((p: any) => p.text || "")
+      .join("");
+    return { answer, cost, ms: Date.now() - started };
+  } catch (err: any) {
+    return { answer: "", cost: null, ms: Date.now() - started, error: err.message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseCostHeader(h: Headers): number | null {
+  const v = h.get("X-Opper-Cost") || h.get("x-opper-cost");
+  if (!v) return null;
+  const n = parseFloat(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+// ---------------------------------------------------------------------------
+// Express plumbing
+// ---------------------------------------------------------------------------
+
+const app = express();
+app.use(express.json());
+app.use(express.static(join(__dirname, "public")));
+
+app.post("/api/ask", async (req, res) => {
+  const question: string = (req.body?.question || "").toString().trim();
+  if (!question) return res.status(400).json({ error: "question is required" });
+
+  const [anthropic, openai, google] = await Promise.all([
+    askAnthropic(question),
+    askOpenAI(question),
+    askGoogle(question),
+  ]);
+
+  res.json({ anthropic, openai, google });
+});
+
+const PORT = await findPort(PREFERRED_PORT);
+app.listen(PORT, () => {
+  console.log(`server-tools-compare listening on http://localhost:${PORT}`);
+});

--- a/examples/server-tools-compare/server.ts
+++ b/examples/server-tools-compare/server.ts
@@ -259,18 +259,22 @@ const app = express();
 app.use(express.json());
 app.use(express.static(join(__dirname, "public")));
 
-app.post("/api/ask", async (req, res) => {
+// One endpoint per provider so the browser can fire all three in parallel
+// and paint each column the moment its provider finishes — no waiting on
+// the slowest. The shape of every response is the same ProviderResult JSON.
+const ASKERS: Record<string, (q: string, o: AskOptions) => Promise<ProviderResult>> = {
+  anthropic: askAnthropic,
+  openai: askOpenAI,
+  google: askGoogle,
+};
+
+app.post("/api/ask/:provider", async (req, res) => {
+  const asker = ASKERS[req.params.provider];
+  if (!asker) return res.status(404).json({ error: `unknown provider: ${req.params.provider}` });
   const question: string = (req.body?.question || "").toString().trim();
   if (!question) return res.status(400).json({ error: "question is required" });
   const opts: AskOptions = { compact: !!req.body?.compact };
-
-  const [anthropic, openai, google] = await Promise.all([
-    askAnthropic(question, opts),
-    askOpenAI(question, opts),
-    askGoogle(question, opts),
-  ]);
-
-  res.json({ anthropic, openai, google });
+  res.json(await asker(question, opts));
 });
 
 const PORT = await findPort(PREFERRED_PORT);

--- a/examples/server-tools-compare/server.ts
+++ b/examples/server-tools-compare/server.ts
@@ -1,7 +1,7 @@
 /**
  * Server-tools compare: fans the same question out to Anthropic, OpenAI,
  * and Google server-side web search through Opper's compat endpoints,
- * then returns the three answers + citations + costs side by side.
+ * then returns the three answers + queries + citations + costs side by side.
  *
  * Each provider runs its tool internally — no client-side round trip —
  * so this is a tight demo of what server-side tools actually buy you
@@ -44,26 +44,52 @@ async function findPort(start: number, end = start + 20): Promise<number> {
 // Response shape returned to the browser
 // ---------------------------------------------------------------------------
 
+interface Citation {
+  title: string;
+  url?: string; // optional — compact mode strips Google groundingChunk URIs
+}
+
 interface ProviderResult {
   answer: string;
-  cost: number | null;       // dollars, from X-Opper-Cost
+  queries: string[];     // search queries the provider actually issued
+  citations: Citation[]; // sources the answer is grounded in
+  cost: number | null;   // dollars, from X-Opper-Cost
+  bytes: number;         // size of the upstream response body
   ms: number;
   error?: string;
 }
 
+interface AskOptions {
+  compact: boolean;
+}
+
+function compatHeaders(opts: AskOptions): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Authorization": `Bearer ${OPPER_API_KEY}`,
+    "Content-Type": "application/json",
+  };
+  if (opts.compact) headers["X-Opper-Compact-Response"] = "true";
+  return headers;
+}
+
 // ---------------------------------------------------------------------------
 // Anthropic — POST /v3/compat/v1/messages with web_search_20250305
+//
+// Response shape (post phase-2):
+//   content: [
+//     { type:"server_tool_use", name:"web_search", input:{query} },
+//     { type:"web_search_tool_result", content:[{type:"web_search_result", url, title, ...}] },
+//     { type:"text", text, citations?:[{type:"web_search_result_location", url, title, cited_text, ...}] },
+//     ...
+//   ]
 // ---------------------------------------------------------------------------
 
-async function askAnthropic(question: string): Promise<ProviderResult> {
+async function askAnthropic(question: string, opts: AskOptions): Promise<ProviderResult> {
   const started = Date.now();
   try {
     const res = await fetch(`${OPPER_BASE_URL}/v3/compat/v1/messages`, {
       method: "POST",
-      headers: {
-        "Authorization": `Bearer ${OPPER_API_KEY}`,
-        "Content-Type": "application/json",
-      },
+      headers: compatHeaders(opts),
       body: JSON.stringify({
         model: ANTHROPIC_MODEL,
         max_tokens: 1024,
@@ -72,32 +98,49 @@ async function askAnthropic(question: string): Promise<ProviderResult> {
       }),
     });
     const cost = parseCostHeader(res.headers);
-    const body = await res.json() as any;
+    const raw = await res.text();
+    const body = JSON.parse(raw) as any;
     if (!res.ok) throw new Error(body?.error?.message || `HTTP ${res.status}`);
 
-    const answer = (body.content || [])
-      .filter((b: any) => b.type === "text")
-      .map((b: any) => b.text)
-      .join("");
-    return { answer, cost, ms: Date.now() - started };
+    let answer = "";
+    const queries: string[] = [];
+    const citations: Citation[] = [];
+
+    for (const block of body.content || []) {
+      if (block.type === "text") {
+        answer += block.text || "";
+        for (const c of block.citations || []) {
+          if (c.url) citations.push({ title: c.title || c.url, url: c.url });
+        }
+      } else if (block.type === "server_tool_use" && block.name === "web_search") {
+        const q = block.input?.query;
+        if (typeof q === "string") queries.push(q);
+      }
+    }
+    return { answer, queries, citations: dedupeCitations(citations), cost, bytes: raw.length, ms: Date.now() - started };
   } catch (err: any) {
-    return { answer: "", cost: null, ms: Date.now() - started, error: err.message };
+    return { answer: "", queries: [], citations: [], cost: null, bytes: 0, ms: Date.now() - started, error: err.message };
   }
 }
 
 // ---------------------------------------------------------------------------
 // OpenAI — POST /v3/compat/responses with {type:"web_search"}
+//
+// Response shape (post phase-2):
+//   output: [
+//     { type:"web_search_call", action:{type:"search", queries:[...]} },
+//     { type:"message", content:[{type:"output_text", text, annotations:[
+//         { type:"url_citation", url, title, start_index, end_index }
+//       ]}] },
+//   ]
 // ---------------------------------------------------------------------------
 
-async function askOpenAI(question: string): Promise<ProviderResult> {
+async function askOpenAI(question: string, opts: AskOptions): Promise<ProviderResult> {
   const started = Date.now();
   try {
     const res = await fetch(`${OPPER_BASE_URL}/v3/compat/responses`, {
       method: "POST",
-      headers: {
-        "Authorization": `Bearer ${OPPER_API_KEY}`,
-        "Content-Type": "application/json",
-      },
+      headers: compatHeaders(opts),
       body: JSON.stringify({
         model: OPENAI_MODEL,
         input: question,
@@ -105,50 +148,85 @@ async function askOpenAI(question: string): Promise<ProviderResult> {
       }),
     });
     const cost = parseCostHeader(res.headers);
-    const body = await res.json() as any;
+    const raw = await res.text();
+    const body = JSON.parse(raw) as any;
     if (!res.ok) throw new Error(body?.error?.message || `HTTP ${res.status}`);
 
-    const answer = body.output_text
-      || (body.output || [])
-        .flatMap((item: any) => item.type === "message" ? (item.content || []) : [])
-        .filter((p: any) => p.type === "output_text")
-        .map((p: any) => p.text || "")
-        .join("");
-    return { answer, cost, ms: Date.now() - started };
+    let answer = "";
+    const queries: string[] = [];
+    const citations: Citation[] = [];
+
+    for (const item of body.output || []) {
+      if (item.type === "web_search_call") {
+        const qs = item.action?.queries;
+        if (Array.isArray(qs)) for (const q of qs) if (typeof q === "string") queries.push(q);
+      } else if (item.type === "message" && Array.isArray(item.content)) {
+        for (const part of item.content) {
+          if (part.type === "output_text") {
+            answer += part.text || "";
+            for (const a of part.annotations || []) {
+              if (a.type === "url_citation" && a.url) {
+                citations.push({ title: a.title || a.url, url: a.url });
+              }
+            }
+          }
+        }
+      }
+    }
+    return { answer, queries, citations: dedupeCitations(citations), cost, bytes: raw.length, ms: Date.now() - started };
   } catch (err: any) {
-    return { answer: "", cost: null, ms: Date.now() - started, error: err.message };
+    return { answer: "", queries: [], citations: [], cost: null, bytes: 0, ms: Date.now() - started, error: err.message };
   }
 }
 
 // ---------------------------------------------------------------------------
 // Google — POST /v3/compat/v1beta/models/{model}:generateContent with googleSearch
+//
+// Response shape (post phase-2):
+//   candidates: [{
+//     content: { parts: [{text}, ...] },
+//     groundingMetadata: {
+//       webSearchQueries: [...],
+//       groundingChunks: [{web:{uri, title}}, ...],
+//       searchEntryPoint: {...},
+//     }
+//   }]
 // ---------------------------------------------------------------------------
 
-async function askGoogle(question: string): Promise<ProviderResult> {
+async function askGoogle(question: string, opts: AskOptions): Promise<ProviderResult> {
   const started = Date.now();
   try {
     const url = `${OPPER_BASE_URL}/v3/compat/v1beta/models/${encodeURIComponent(GOOGLE_MODEL)}:generateContent`;
     const res = await fetch(url, {
       method: "POST",
-      headers: {
-        "Authorization": `Bearer ${OPPER_API_KEY}`,
-        "Content-Type": "application/json",
-      },
+      headers: compatHeaders(opts),
       body: JSON.stringify({
         contents: [{ role: "user", parts: [{ text: question }] }],
         tools: [{ googleSearch: {} }],
       }),
     });
     const cost = parseCostHeader(res.headers);
-    const body = await res.json() as any;
+    const raw = await res.text();
+    const body = JSON.parse(raw) as any;
     if (!res.ok) throw new Error(body?.error?.message || `HTTP ${res.status}`);
 
-    const answer = (body.candidates?.[0]?.content?.parts || [])
+    const candidate = body.candidates?.[0];
+    const answer = (candidate?.content?.parts || [])
       .map((p: any) => p.text || "")
       .join("");
-    return { answer, cost, ms: Date.now() - started };
+    const gm = candidate?.groundingMetadata || {};
+    const queries: string[] = Array.isArray(gm.webSearchQueries) ? gm.webSearchQueries.filter((q: any) => typeof q === "string") : [];
+    const citations: Citation[] = [];
+    for (const chunk of gm.groundingChunks || []) {
+      const web = chunk.web;
+      if (!web) continue;
+      const title = web.title || web.uri;
+      if (!title) continue;
+      citations.push(web.uri ? { title, url: web.uri } : { title });
+    }
+    return { answer, queries, citations: dedupeCitations(citations), cost, bytes: raw.length, ms: Date.now() - started };
   } catch (err: any) {
-    return { answer: "", cost: null, ms: Date.now() - started, error: err.message };
+    return { answer: "", queries: [], citations: [], cost: null, bytes: 0, ms: Date.now() - started, error: err.message };
   }
 }
 
@@ -163,6 +241,16 @@ function parseCostHeader(h: Headers): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+function dedupeCitations(citations: Citation[]): Citation[] {
+  const seen = new Set<string>();
+  return citations.filter(c => {
+    const key = c.url || c.title;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Express plumbing
 // ---------------------------------------------------------------------------
@@ -174,11 +262,12 @@ app.use(express.static(join(__dirname, "public")));
 app.post("/api/ask", async (req, res) => {
   const question: string = (req.body?.question || "").toString().trim();
   if (!question) return res.status(400).json({ error: "question is required" });
+  const opts: AskOptions = { compact: !!req.body?.compact };
 
   const [anthropic, openai, google] = await Promise.all([
-    askAnthropic(question),
-    askOpenAI(question),
-    askGoogle(question),
+    askAnthropic(question, opts),
+    askOpenAI(question, opts),
+    askGoogle(question, opts),
   ]);
 
   res.json({ anthropic, openai, google });

--- a/examples/server-tools-compare/tsconfig.json
+++ b/examples/server-tools-compare/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
## Summary

New example: **server-tools-compare** — side-by-side web search across Anthropic / OpenAI / Google server-side tools through Opper's compat endpoints.

One question fans out in parallel to:
- Anthropic \`web_search_20250305\` → \`POST /v3/compat/v1/messages\`
- OpenAI \`web_search\` → \`POST /v3/compat/responses\`
- Google \`googleSearch\` → \`POST /v3/compat/v1beta/models/gemini-2.5-flash:generateContent\`

Each provider runs its own search internally — no client-side tool round trip. UI shows the answer (with inline markdown citations rendered as clickable links), latency, and Opper-reported cost per provider.

Built with Express + a single static HTML page, styled to match the brainstorm-time / opper-tour aesthetic (Tailwind + Wix Madefor + OKLCH variables). No SDK dependency — just \`fetch\` to the three compat endpoints.

## Test plan

- [ ] \`npm install\` and \`OPPER_API_KEY=... npm start\` boots
- [ ] http://localhost:3000 renders three columns
- [ ] Clicking an example chip fires the question across all three providers
- [ ] Each column shows answer, latency, and cost; provider errors render inline