### PR TITLE
Bump server-tools-compare defaults to sonnet-4-6 / gpt-5.5

### DIFF
--- a/examples/server-tools-compare/README.md
+++ b/examples/server-tools-compare/README.md
@@ -32,8 +32,8 @@ Open http://localhost:3000.
 | --- | --- | --- |
 | `OPPER_API_KEY` | (required) | Opper key — get one at https://opper.ai |
 | `OPPER_BASE_URL` | `https://api.opper.ai` | Override for staging / local stack |
-| `ANTHROPIC_MODEL` | `anthropic/claude-sonnet-4-5` | Any Claude model with `web_search_*` support |
-| `OPENAI_MODEL` | `openai/gpt-5` | Any OpenAI model with Responses API support |
+| `ANTHROPIC_MODEL` | `anthropic/claude-sonnet-4-6` | Any Claude model with `web_search_*` support |
+| `OPENAI_MODEL` | `openai/gpt-5.5` | Any OpenAI model with Responses API support |
 | `GOOGLE_MODEL` | `gemini-2.5-flash` | Any Gemini model with grounding support |
 
 ## How it works

--- a/examples/server-tools-compare/public/index.html
+++ b/examples/server-tools-compare/public/index.html
@@ -204,7 +204,7 @@
         <div class="col-header">
           <span class="col-swatch" style="background: var(--anthropic)"></span>
           Anthropic
-          <span class="text-xs font-normal" style="color: var(--muted-foreground)">claude-sonnet-4-5</span>
+          <span class="text-xs font-normal" style="color: var(--muted-foreground)">claude-sonnet-4-6</span>
         </div>
         <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
         <div class="col-section" data-slot="queries-section" hidden>
@@ -222,7 +222,7 @@
         <div class="col-header">
           <span class="col-swatch" style="background: var(--openai)"></span>
           OpenAI
-          <span class="text-xs font-normal" style="color: var(--muted-foreground)">gpt-5</span>
+          <span class="text-xs font-normal" style="color: var(--muted-foreground)">gpt-5.5</span>
         </div>
         <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
         <div class="col-section" data-slot="queries-section" hidden>

--- a/examples/server-tools-compare/server.ts
+++ b/examples/server-tools-compare/server.ts
@@ -24,8 +24,8 @@ if (!OPPER_API_KEY) {
   process.exit(1);
 }
 
-const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || "anthropic/claude-sonnet-4-5";
-const OPENAI_MODEL = process.env.OPENAI_MODEL || "openai/gpt-5";
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || "anthropic/claude-sonnet-4-6";
+const OPENAI_MODEL = process.env.OPENAI_MODEL || "openai/gpt-5.5";
 const GOOGLE_MODEL = process.env.GOOGLE_MODEL || "gemini-2.5-flash";
 
 async function findPort(start: number, end = start + 20): Promise<number> {


### PR DESCRIPTION
Switch the default models from claude-sonnet-4-5 / gpt-5 to the newer claude-sonnet-4-6 / gpt-5.5. Live-verified against api.opper.ai — all three providers return the expected rich shape (queries, citations, costs).

| Provider | Bytes | Cost | Latency |
| --- | --- | --- | --- |
| anthropic/claude-sonnet-4-6 | 42 KB | \$0.020 | 4.8s |
| openai/gpt-5.5 | 1.2 KB | \$0.036 | 17.2s |
| gemini-2.5-flash | 6.7 KB | \$0.035 | 2.9s |