### PR TITLE
server-tools-compare: add engine selector + preset switcher

### DIFF
--- a/examples/server-tools-compare/README.md
+++ b/examples/server-tools-compare/README.md
@@ -1,18 +1,29 @@
 # server-tools-compare
 
-Side-by-side comparison of Anthropic, OpenAI, and Google **server-side web search** through Opper's compat endpoints.
+Side-by-side comparison of how Opper's compat endpoints route **server-side web search**, across providers and across engines for the same model.
 
-One question gets fanned out to three providers in parallel; each provider runs its own search internally (no client-side tool round trip) and returns the final answer plus the actual search queries it issued and citation URLs for every source it grounded on. The UI shows answer, queries, citations, latency, cost, and response size per provider.
+One question fans out to N panels in parallel; each panel runs its own search internally (no client-side tool round trip) and returns the final answer plus the actual search queries it issued and citation URLs for every source it grounded on. The UI shows answer, queries, citations, latency, cost, and response size per panel.
 
-## What this demonstrates
+## Presets
 
-- **Server-side tools across all three providers** on a single API key
+Switch between presets via the tabs at the top of the page:
+
+- **Providers (native)** — the original demo. Three panels, each provider calling its own native server-tool block.
   - Anthropic `web_search_20250305` → `POST /v3/compat/v1/messages`
   - OpenAI `web_search` → `POST /v3/compat/responses`
   - Google `googleSearch` → `POST /v3/compat/v1beta/models/{model}:generateContent`
-- **No tool-result round trip** — the model invokes the tool, the provider runs it, you get the answer back in one response
-- **Full provider-native response fidelity** — every endpoint round-trips its provider's server-tool blocks verbatim (Anthropic `server_tool_use` + `web_search_tool_result` + text `citations[]`; OpenAI `web_search_call` + `url_citation` annotations; Google `groundingMetadata`)
-- **Surcharge billing** surfaced live via the `X-Opper-Cost` response header — token cost plus the per-provider server-tool surcharge (e.g. $0.01/search for Anthropic web_search, $0.035/prompt for Google grounding)
+- **Claude — all engines**, **GPT-5.5 — all engines**, **Gemini — all engines** — five panels for the same model, one per engine selector. Shows the same question routed through:
+  - `native` — provider's own server-tool block (same as the Providers preset)
+  - `auto` — `{type:"opper:web_search", engine:"auto"}`. Server resolver routes to native when the model declares `server_tools.web_search=native` on this endpoint, otherwise falls back to the opper agentic loop
+  - `opper` — forces the opper server-side agentic loop regardless of native capability
+  - `jina` / `exa` — opper agentic loop with the named search backend
+
+## What this demonstrates
+
+- **Server-side tools across providers** on a single API key — no client-side tool loop, the model invokes the tool, the provider (or Opper) runs it, you get the final answer back in one response.
+- **Engine routing is one selector** — drop `{type:"opper:web_search", engine:"<engine>"}` into your tools array. The same request body works on every compat endpoint; what changes is who actually executes the search.
+- **Full wire-shape fidelity** — every endpoint returns its provider's native server-tool blocks verbatim (Anthropic `server_tool_use` + `web_search_tool_result` + text `citations[]`; OpenAI `web_search_call` + `url_citation` annotations; Google `groundingMetadata`). The opper route synthesizes the same shape, so client parsing stays uniform.
+- **Surcharge billing** surfaced live via the `X-Opper-Cost` response header — token cost plus the per-engine surcharge (e.g. $0.01/search for Anthropic native, $0.035/prompt for Google grounding, Jina/Exa rates for opper-route backends). The cost diverges between presets, which is the demo's point.
 - **Compact-response toggle** — flip the checkbox to enable `X-Opper-Compact-Response: true` and watch the Anthropic response shrink ~90% (encrypted_content stripped, citation URLs preserved). Tradeoff documented inline.
 
 ## Run
@@ -33,23 +44,23 @@ Open http://localhost:3000.
 | `OPPER_API_KEY` | (required) | Opper key — get one at https://opper.ai |
 | `OPPER_BASE_URL` | `https://api.opper.ai` | Override for staging / local stack |
 | `ANTHROPIC_MODEL` | `anthropic/claude-sonnet-4-6` | Any Claude model with `web_search_*` support |
-| `OPENAI_MODEL` | `openai/gpt-5.5` | Any OpenAI model with Responses API support |
-| `GOOGLE_MODEL` | `gemini-2.5-flash` | Any Gemini model with grounding support |
+| `OPENAI_MODEL` | `openai/gpt-5.5` | Any OpenAI model with Responses-API `web_search` support |
+| `GOOGLE_MODEL` | `gemini-2.5-flash` | Any Gemini model with `google_search` grounding support |
 
 ## How it works
 
-`server.ts` has three short adapter functions — one per provider — each making a single `fetch` to the corresponding compat endpoint. Request bodies use the provider's native shape; Opper forwards them verbatim. Each adapter walks the provider-specific response envelope to pull out:
+`server.ts` exposes one endpoint: `POST /api/ask` with `{model, engine, question, compact}`. The server derives the compat endpoint from the model prefix (`anthropic/` → `/v1/messages`, `openai/` → `/responses`, `gemini`/`vertexai/gemini` → `/v1beta/models/{model}:generateContent`), builds the request body with either the provider's native tool block (engine `native`) or the canonical `opper:web_search` entry (every other engine), and parses the response with a per-endpoint parser:
 
-- **Answer text** — `content[].text` for Anthropic, `output_text` for OpenAI, `candidates[].content.parts[].text` for Google
-- **Queries** — `server_tool_use.input.query` for Anthropic, `web_search_call.action.queries[]` for OpenAI, `groundingMetadata.webSearchQueries[]` for Google
-- **Citations** — text-block `citations[]` for Anthropic, `output_text.annotations[]` (url_citation) for OpenAI, `groundingMetadata.groundingChunks[].web` for Google
-- **Cost** — `X-Opper-Cost` response header (the same Opper-billed cost in all three cases)
+- **Answer text** — `content[].text` for Messages, `output_text` for Responses, `candidates[].content.parts[].text` for generateContent
+- **Queries** — `server_tool_use.input.query` for Messages (also `tool_use.opper_web_search` when the opper route hits its budget mid-loop), `web_search_call.action.queries[]` for Responses, `groundingMetadata.webSearchQueries[]` for generateContent
+- **Citations** — text-block `citations[]` for Messages, `output_text.annotations[]` (`url_citation`) for Responses, `groundingMetadata.groundingChunks[].web` for generateContent
+- **Cost** — `X-Opper-Cost` response header
 
-The frontend is a single HTML page that POSTs the question to `/api/ask`, then renders the three providers in a grid with skeleton loaders while requests run. A checkbox toggles the `X-Opper-Compact-Response: true` header on or off so you can see the response size difference live.
+The frontend is a single HTML page that fetches `/api/defaults` for the model labels, renders the chosen preset's panels into a CSS-grid layout (`auto-fit, minmax(280px, 1fr)` — adapts cleanly from 3 panels to 5), then fans out one `/api/ask` per panel in parallel and paints each cell as it finishes.
 
 ## Notes
 
-- The cost shown is what Opper bills you per request — token cost plus the provider-specific server-tool surcharge.
-- If you don't have access to a particular provider on your Opper key, that column will show the upstream error inline; the other two still work.
-- In **compact mode**, Google's `groundingChunks` keep titles but drop the (long signed redirect) URIs — those citations render as plain text since there's nothing to link to. Anthropic compact strips `encrypted_content` from search results but preserves the citation URLs.
-- Compact-mode responses **cannot be replayed in multi-turn conversation** to extend a cited turn, because Anthropic's citation continuity needs the `encrypted_content` / `encrypted_index` blobs that compact mode strips. That's the documented contract.
+- Cost shown is what Opper bills you per request — token cost plus the engine's per-call surcharge. In the engine presets, you'll see Native vs Auto match on a model whose YAML declares `server_tools.web_search=native` (because Auto resolves to Native), and Opper/Jina/Exa diverge to the agentic-loop rate.
+- If your Opper key doesn't have access to a particular provider, that panel will show the upstream error inline; the rest still work.
+- **Compact mode**: Google's `groundingChunks` keep titles but drop the (long signed redirect) URIs — those citations render as plain text since there's nothing to link to. Anthropic compact strips `encrypted_content` from search results but preserves citation URLs. Compact-mode responses **cannot be replayed in multi-turn conversation** to extend a cited turn (Anthropic's citation continuity needs the encrypted blobs); the contract is documented.
+- Engine `auto` is the recommended selector for production agents — let Opper pick native when available, fall back to the opper agentic loop otherwise.

--- a/examples/server-tools-compare/README.md
+++ b/examples/server-tools-compare/README.md
@@ -43,7 +43,7 @@ Open http://localhost:3000.
 | --- | --- | --- |
 | `OPPER_API_KEY` | (required) | Opper key — get one at https://opper.ai |
 | `OPPER_BASE_URL` | `https://api.opper.ai` | Override for staging / local stack |
-| `ANTHROPIC_MODEL` | `anthropic/claude-sonnet-4-6` | Any Claude model with `web_search_*` support |
+| `ANTHROPIC_MODEL` | `anthropic/claude-haiku-4-5` | Any Claude model with `web_search_*` support |
 | `OPENAI_MODEL` | `openai/gpt-5.5` | Any OpenAI model with Responses-API `web_search` support |
 | `GOOGLE_MODEL` | `gemini-2.5-flash` | Any Gemini model with `google_search` grounding support |
 

--- a/examples/server-tools-compare/public/index.html
+++ b/examples/server-tools-compare/public/index.html
@@ -20,8 +20,13 @@
       --ring: oklch(0.708 0 0);
       --radius: 0.625rem;
       --anthropic: oklch(0.62 0.16 35);
-      --openai: oklch(0.55 0.13 165);
-      --google: oklch(0.6 0.15 250);
+      --openai:    oklch(0.55 0.13 165);
+      --google:    oklch(0.6 0.15 250);
+      --eng-native: oklch(0.62 0.16 35);   /* matches provider — same shape */
+      --eng-auto:   oklch(0.6 0.15 250);   /* blue — resolver-decided */
+      --eng-opper:  oklch(0.6 0.18 295);   /* purple — agentic loop */
+      --eng-jina:   oklch(0.6 0.15 150);   /* green */
+      --eng-exa:    oklch(0.6 0.15 195);   /* teal */
     }
     @media (prefers-color-scheme: dark) {
       :root {
@@ -65,11 +70,30 @@
       padding: 4px 10px;
     }
     .btn-ghost:hover { color: var(--foreground); }
+    .preset-tabs { display: inline-flex; gap: 4px; padding: 4px; border-radius: var(--radius); background: var(--muted); }
+    .preset-tab {
+      font-size: 12px;
+      padding: 6px 12px;
+      border-radius: calc(var(--radius) - 2px);
+      color: var(--muted-foreground);
+      cursor: pointer;
+      transition: background-color 150ms ease, color 150ms ease;
+      white-space: nowrap;
+    }
+    .preset-tab:hover { color: var(--foreground); }
+    .preset-tab.active { background: var(--card); color: var(--foreground); box-shadow: 0 1px 2px rgba(0,0,0,0.04); }
+    .preset-summary {
+      font-size: 12px;
+      color: var(--muted-foreground);
+      max-width: 64ch;
+      margin-top: 8px;
+    }
     .card {
       background: var(--card);
       border: 1px solid var(--border);
       border-radius: var(--radius);
       display: flex; flex-direction: column;
+      min-width: 0;
     }
     .col-header {
       display: flex; align-items: center; gap: 8px;
@@ -77,7 +101,24 @@
       border-bottom: 1px solid var(--border);
       font-weight: 600; font-size: 13px;
     }
-    .col-swatch { width: 8px; height: 8px; border-radius: 2px; }
+    .col-swatch { width: 8px; height: 8px; border-radius: 2px; flex-shrink: 0; }
+    .engine-chip {
+      font-size: 10px;
+      font-weight: 600;
+      padding: 2px 6px;
+      border-radius: 4px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--card);
+      margin-left: auto;
+    }
+    .col-model {
+      font-size: 11px;
+      font-weight: 400;
+      color: var(--muted-foreground);
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      min-width: 0;
+    }
     .col-body {
       padding: 14px;
       font-size: 14px; line-height: 1.55;
@@ -164,16 +205,35 @@
       user-select: none;
     }
     .toggle input { accent-color: var(--foreground); }
+
+    /* Grid auto-fits panels: at least one panel per row, equal widths,
+       never narrower than 280px. Lets a 5-column engine view render
+       comfortably on wide screens and stack neatly on narrow ones. */
+    #results {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 16px;
+    }
   </style>
 </head>
 <body>
-  <div class="max-w-6xl mx-auto px-6 py-10">
-    <header class="mb-8">
+  <div class="max-w-7xl mx-auto px-6 py-10">
+    <header class="mb-6">
       <h1 class="text-3xl font-semibold mb-2">Server-side tools, side by side</h1>
       <p class="text-sm" style="color: var(--muted-foreground); max-width: 64ch;">
-        One question, fanned out to Anthropic <code>web_search</code>, OpenAI <code>web_search</code>, and Google <code>googleSearch</code> through Opper's compat endpoints in parallel. No client-side tool loop &mdash; each provider runs its own search and returns the final answer plus citations.
+        One question, fanned out across model + engine combinations. The original demo &mdash; three providers each calling their own native server-tool block &mdash; is the default; switch presets to see the same model routed through the <code>opper:web_search</code> engine selector (<code>auto</code>, <code>opper</code>, <code>jina</code>, <code>exa</code>).
       </p>
     </header>
+
+    <div class="mb-3 flex items-center gap-4 flex-wrap">
+      <div class="preset-tabs" role="tablist" id="preset-tabs">
+        <button class="preset-tab active" data-preset="providers" role="tab">Providers (native)</button>
+        <button class="preset-tab" data-preset="anthropic-engines" role="tab">Claude &mdash; all engines</button>
+        <button class="preset-tab" data-preset="openai-engines" role="tab">GPT-5.5 &mdash; all engines</button>
+        <button class="preset-tab" data-preset="google-engines" role="tab">Gemini &mdash; all engines</button>
+      </div>
+    </div>
+    <p class="preset-summary mb-6" id="preset-summary"></p>
 
     <form id="ask-form" class="mb-3 flex gap-2">
       <input
@@ -199,61 +259,7 @@
       </label>
     </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4" id="results">
-      <section class="card" data-provider="anthropic">
-        <div class="col-header">
-          <span class="col-swatch" style="background: var(--anthropic)"></span>
-          Anthropic
-          <span class="text-xs font-normal" style="color: var(--muted-foreground)">claude-sonnet-4-6</span>
-        </div>
-        <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
-        <div class="col-section" data-slot="queries-section" hidden>
-          <div class="col-section-label">Queries</div>
-          <div class="queries" data-slot="queries"></div>
-        </div>
-        <div class="col-section" data-slot="citations-section" hidden>
-          <div class="col-section-label">Citations</div>
-          <div class="citations" data-slot="citations"></div>
-        </div>
-        <div class="col-meta" data-slot="meta"></div>
-      </section>
-
-      <section class="card" data-provider="openai">
-        <div class="col-header">
-          <span class="col-swatch" style="background: var(--openai)"></span>
-          OpenAI
-          <span class="text-xs font-normal" style="color: var(--muted-foreground)">gpt-5.5</span>
-        </div>
-        <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
-        <div class="col-section" data-slot="queries-section" hidden>
-          <div class="col-section-label">Queries</div>
-          <div class="queries" data-slot="queries"></div>
-        </div>
-        <div class="col-section" data-slot="citations-section" hidden>
-          <div class="col-section-label">Citations</div>
-          <div class="citations" data-slot="citations"></div>
-        </div>
-        <div class="col-meta" data-slot="meta"></div>
-      </section>
-
-      <section class="card" data-provider="google">
-        <div class="col-header">
-          <span class="col-swatch" style="background: var(--google)"></span>
-          Google
-          <span class="text-xs font-normal" style="color: var(--muted-foreground)">gemini-2.5-flash</span>
-        </div>
-        <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
-        <div class="col-section" data-slot="queries-section" hidden>
-          <div class="col-section-label">Queries</div>
-          <div class="queries" data-slot="queries"></div>
-        </div>
-        <div class="col-section" data-slot="citations-section" hidden>
-          <div class="col-section-label">Citations</div>
-          <div class="citations" data-slot="citations"></div>
-        </div>
-        <div class="col-meta" data-slot="meta"></div>
-      </section>
-    </div>
+    <div id="results"></div>
   </div>
 
   <script>
@@ -261,6 +267,126 @@
     const input = document.getElementById('question');
     const askBtn = document.getElementById('ask');
     const compactToggle = document.getElementById('compact');
+    const resultsEl = document.getElementById('results');
+    const presetTabs = document.getElementById('preset-tabs');
+    const presetSummary = document.getElementById('preset-summary');
+
+    // Provider colors (for the swatch on each card header).
+    const PROVIDER_COLOR = {
+      anthropic: 'var(--anthropic)',
+      openai:    'var(--openai)',
+      google:    'var(--google)',
+    };
+    function providerOf(model) {
+      if (model.startsWith('anthropic/')) return 'anthropic';
+      if (model.startsWith('openai/'))    return 'openai';
+      if (model.startsWith('gemini') || model.startsWith('vertexai/gemini')) return 'google';
+      return 'unknown';
+    }
+    function providerLabel(p) {
+      return p === 'anthropic' ? 'Anthropic' : p === 'openai' ? 'OpenAI' : p === 'google' ? 'Google' : 'Model';
+    }
+
+    // Engine colors and labels (for the chip on each card header).
+    const ENGINES = ['native', 'auto', 'opper', 'jina', 'exa'];
+    const ENGINE_COLOR = {
+      native: 'var(--eng-native)',
+      auto:   'var(--eng-auto)',
+      opper:  'var(--eng-opper)',
+      jina:   'var(--eng-jina)',
+      exa:    'var(--eng-exa)',
+    };
+
+    // Server defaults fetched on load. The preset definitions key off
+    // these so users can swap models via env vars without editing HTML.
+    let defaults = null;
+    let presets = null;
+    let currentPanels = [];
+
+    async function loadDefaults() {
+      const res = await fetch('/api/defaults');
+      defaults = await res.json();
+      presets = buildPresets(defaults);
+      applyPreset('providers');
+    }
+
+    function buildPresets(d) {
+      return {
+        'providers': {
+          summary: `Original demo: each provider calling its own native server-tool block. Anthropic ${escapeHtml(d.anthropic)}, OpenAI ${escapeHtml(d.openai)}, Google ${escapeHtml(d.google)}.`,
+          panels: [
+            { id: 'anthropic-native', model: d.anthropic, engine: 'native' },
+            { id: 'openai-native',    model: d.openai,    engine: 'native' },
+            { id: 'google-native',    model: d.google,    engine: 'native' },
+          ],
+        },
+        'anthropic-engines': {
+          summary: `Same model (${escapeHtml(d.anthropic)}) routed through every engine. Compare cost, latency, and how the answer shifts when the native upstream search is swapped for Opper's agentic loop with Jina/Exa.`,
+          panels: ENGINES.map(e => ({ id: `anthropic-${e}`, model: d.anthropic, engine: e })),
+        },
+        'openai-engines': {
+          summary: `Same model (${escapeHtml(d.openai)}) routed through every engine.`,
+          panels: ENGINES.map(e => ({ id: `openai-${e}`, model: d.openai, engine: e })),
+        },
+        'google-engines': {
+          summary: `Same model (${escapeHtml(d.google)}) routed through every engine. Native uses Gemini's <code>googleSearch</code> grounding; auto resolves to the same since this model declares server_tools.web_search=native.`,
+          panels: ENGINES.map(e => ({ id: `google-${e}`, model: d.google, engine: e })),
+        },
+      };
+    }
+
+    function applyPreset(key) {
+      const preset = presets[key];
+      if (!preset) return;
+      for (const t of presetTabs.querySelectorAll('.preset-tab')) {
+        t.classList.toggle('active', t.dataset.preset === key);
+      }
+      presetSummary.innerHTML = preset.summary;
+      currentPanels = preset.panels;
+      renderPanels(preset.panels);
+    }
+
+    function renderPanels(panels) {
+      resultsEl.innerHTML = panels.map(panelHtml).join('');
+    }
+
+    function panelHtml(p) {
+      const provider = providerOf(p.model);
+      const swatch = PROVIDER_COLOR[provider] || 'var(--muted-foreground)';
+      const engineColor = ENGINE_COLOR[p.engine] || 'var(--muted-foreground)';
+      return `
+        <section class="card" data-panel-id="${escapeAttr(p.id)}">
+          <div class="col-header">
+            <span class="col-swatch" style="background: ${swatch}"></span>
+            <span>${providerLabel(provider)}</span>
+            <span class="col-model" title="${escapeAttr(p.model)}">${escapeHtml(shortModel(p.model))}</span>
+            <span class="engine-chip" style="background: ${engineColor}">${escapeHtml(p.engine)}</span>
+          </div>
+          <div class="col-body" data-slot="answer"><span style="color: var(--muted-foreground)">Ask a question to compare.</span></div>
+          <div class="col-section" data-slot="queries-section" hidden>
+            <div class="col-section-label">Queries</div>
+            <div class="queries" data-slot="queries"></div>
+          </div>
+          <div class="col-section" data-slot="citations-section" hidden>
+            <div class="col-section-label">Citations</div>
+            <div class="citations" data-slot="citations"></div>
+          </div>
+          <div class="col-meta" data-slot="meta"></div>
+        </section>
+      `;
+    }
+
+    function shortModel(model) {
+      // Drop the provider prefix for header display; the full model id is in the tooltip.
+      const slash = model.indexOf('/');
+      return slash >= 0 ? model.slice(slash + 1) : model;
+    }
+
+    presetTabs.addEventListener('click', (e) => {
+      const tab = e.target.closest('.preset-tab');
+      if (!tab) return;
+      applyPreset(tab.dataset.preset);
+    });
 
     document.getElementById('examples').addEventListener('click', (e) => {
       const btn = e.target.closest('button[data-q]');
@@ -274,37 +400,43 @@
       const q = input.value.trim();
       if (!q) return;
       setLoading(true);
-      const payload = JSON.stringify({ question: q, compact: compactToggle.checked });
-      // Fan out: three independent requests; each column paints as soon
-      // as its provider finishes, so the fast one (often Google ~2s) shows
-      // up without waiting for the slow one (often OpenAI ~20s).
-      const tasks = ['anthropic', 'openai', 'google'].map(async (provider) => {
-        try {
-          const res = await fetch(`/api/ask/${provider}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: payload,
-          });
-          const data = await res.json();
-          if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
-          renderProvider(provider, data);
-        } catch (err) {
-          renderProvider(provider, { error: err.message });
-        }
-      });
       try {
-        await Promise.all(tasks);
+        // Fan out: every panel fires in parallel; each cell paints as
+        // soon as its request finishes so the fast ones don't wait on
+        // the slow ones (auto routes can take 20s+ on agentic loops).
+        await Promise.all(currentPanels.map(p => runPanel(p, q)));
       } finally {
         setLoading(false);
       }
     });
 
+    async function runPanel(panel, question) {
+      try {
+        const res = await fetch('/api/ask', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            model: panel.model,
+            engine: panel.engine,
+            question,
+            compact: compactToggle.checked,
+          }),
+        });
+        const data = await res.json();
+        if (!res.ok && !data.error) throw new Error(data.error || `HTTP ${res.status}`);
+        renderResult(panel.id, data);
+      } catch (err) {
+        renderResult(panel.id, { error: err.message });
+      }
+    }
+
     function setLoading(on) {
       askBtn.disabled = on;
       askBtn.textContent = on ? 'Asking…' : 'Ask';
       if (!on) return;
-      for (const p of ['anthropic', 'openai', 'google']) {
-        const section = document.querySelector(`[data-provider="${p}"]`);
+      for (const p of currentPanels) {
+        const section = document.querySelector(`[data-panel-id="${cssEscape(p.id)}"]`);
+        if (!section) continue;
         section.querySelector('[data-slot="answer"]').innerHTML = `
           <div class="flex flex-col gap-2">
             <div class="skeleton-line" style="width: 90%"></div>
@@ -318,8 +450,9 @@
       }
     }
 
-    function renderProvider(name, r) {
-      const section = document.querySelector(`[data-provider="${name}"]`);
+    function renderResult(panelId, r) {
+      const section = document.querySelector(`[data-panel-id="${cssEscape(panelId)}"]`);
+      if (!section) return;
       const answer = section.querySelector('[data-slot="answer"]');
       const meta = section.querySelector('[data-slot="meta"]');
       const qSection = section.querySelector('[data-slot="queries-section"]');
@@ -349,8 +482,6 @@
       if (citations.length) {
         cSection.hidden = false;
         cList.innerHTML = citations.slice(0, 8).map(c => {
-          // Compact mode strips Google groundingChunk URIs (titles preserved);
-          // render those as plain text since there's nothing to link to.
           const titleHtml = c.url
             ? `<a href="${escapeAttr(c.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(c.title)}</a>`
             : escapeHtml(c.title);
@@ -370,8 +501,6 @@
       ].filter(Boolean).join('');
     }
 
-    // Light markdown-link rendering — providers cite sources inline as
-    // [title](url). Everything else stays as plain text.
     function renderAnswer(s) {
       const escaped = escapeHtml(s);
       return escaped.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, (_, title, url) =>
@@ -396,6 +525,14 @@
       }[c]));
     }
     function escapeAttr(s) { return escapeHtml(s); }
+
+    // Tiny CSS.escape polyfill — panel IDs are safe ASCII so this only
+    // needs to handle the chars we generate (letters/digits/hyphens).
+    function cssEscape(s) {
+      return (window.CSS && CSS.escape) ? CSS.escape(s) : String(s).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+    }
+
+    loadDefaults();
   </script>
 </body>
 </html>

--- a/examples/server-tools-compare/server.ts
+++ b/examples/server-tools-compare/server.ts
@@ -35,7 +35,7 @@ if (!OPPER_API_KEY) {
   process.exit(1);
 }
 
-const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || "anthropic/claude-sonnet-4-6";
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || "anthropic/claude-haiku-4-5";
 const OPENAI_MODEL = process.env.OPENAI_MODEL || "openai/gpt-5.5";
 const GOOGLE_MODEL = process.env.GOOGLE_MODEL || "gemini-2.5-flash";
 
@@ -104,12 +104,22 @@ function endpointFor(model: string): { kind: EndpointKind; url: string } {
   throw new Error(`unsupported model prefix: ${model}`);
 }
 
+// Bounds the per-request search budget so the demo finishes quickly
+// across all engines. Applied to surfaces that honor it (Anthropic
+// native web_search_20250305 and the canonical opper:web_search entry).
+// OpenAI native web_search and Google googleSearch don't expose a
+// max_uses control — they cap implicitly via reasoning effort / model
+// behavior. 4 is a balance: enough that complex questions can do a
+// couple of refining queries, low enough that demo latency stays
+// reasonable.
+const MAX_SEARCHES = 4;
+
 function toolBlockFor(kind: EndpointKind, engine: Engine): unknown {
   if (engine === "native") {
     // The original demo path — provider's own server-tool entry. Each
     // compat endpoint round-trips this verbatim to the upstream.
     switch (kind) {
-      case "messages":        return { type: "web_search_20250305", name: "web_search", max_uses: 3 };
+      case "messages":        return { type: "web_search_20250305", name: "web_search", max_uses: MAX_SEARCHES };
       case "responses":       return { type: "web_search" };
       case "generateContent": return { googleSearch: {} };
     }
@@ -118,7 +128,7 @@ function toolBlockFor(kind: EndpointKind, engine: Engine): unknown {
   // selector. The server's resolver routes it: auto → native when the
   // model declares server_tools.web_search=native and the endpoint matches,
   // opper/jina/exa → server-side agentic loop with the named backend.
-  return { type: "opper:web_search", engine };
+  return { type: "opper:web_search", engine, max_uses: MAX_SEARCHES };
 }
 
 function buildBody(kind: EndpointKind, model: string, question: string, tool: unknown): unknown {
@@ -195,11 +205,19 @@ function parseResponses(body: any): Parsed {
   for (const item of body?.output || []) {
     if (item.type === "web_search_call") {
       // Both shapes: action.queries (array, native multi-query call) and
-      // action.query (scalar, per-search emitted by some routes).
+      // action.query (scalar, per-search emitted by some routes). Braces
+      // are mandatory — without them the `else` binds to the inner `if`,
+      // not the outer Array.isArray check, and synthesized blocks with
+      // only action.query fall through silently.
       const qs = item.action?.queries;
       const q = item.action?.query;
-      if (Array.isArray(qs)) for (const qq of qs) if (typeof qq === "string") queries.push(qq);
-      else if (typeof q === "string") queries.push(q);
+      if (Array.isArray(qs)) {
+        for (const qq of qs) {
+          if (typeof qq === "string") queries.push(qq);
+        }
+      } else if (typeof q === "string") {
+        queries.push(q);
+      }
     } else if (item.type === "message" && Array.isArray(item.content)) {
       for (const part of item.content) {
         if (part.type === "output_text") {

--- a/examples/server-tools-compare/server.ts
+++ b/examples/server-tools-compare/server.ts
@@ -1,11 +1,22 @@
 /**
- * Server-tools compare: fans the same question out to Anthropic, OpenAI,
- * and Google server-side web search through Opper's compat endpoints,
- * then returns the three answers + queries + citations + costs side by side.
+ * Server-tools compare: renders the same question across model + engine
+ * combinations to show how Opper's compat endpoints route web_search.
  *
- * Each provider runs its tool internally — no client-side round trip —
- * so this is a tight demo of what server-side tools actually buy you
- * vs the function-tool pattern.
+ * Two demo modes the UI toggles between:
+ *
+ *  - Providers preset (default, matches the original demo): three panels,
+ *    one per provider, each sending its own native server-tool block
+ *    (Anthropic web_search_20250305, OpenAI web_search, Google
+ *    googleSearch).
+ *  - Engine presets: one model, multiple engine selectors (native, auto,
+ *    opper, jina, exa). Shows the same question routed through the
+ *    different web_search engines — auto picks native when the routed
+ *    model declares server_tools.web_search=native, falls back to the
+ *    opper agentic loop otherwise. opper/jina/exa force the agentic loop
+ *    with the named backend.
+ *
+ * Regardless of which engine ran, the response wire shape matches the
+ * endpoint's provider native shape, so the parsers below are uniform.
  */
 
 import express from "express";
@@ -41,192 +52,253 @@ async function findPort(start: number, end = start + 20): Promise<number> {
 }
 
 // ---------------------------------------------------------------------------
-// Response shape returned to the browser
+// Types
 // ---------------------------------------------------------------------------
+
+type Engine = "native" | "auto" | "opper" | "jina" | "exa";
+type EndpointKind = "messages" | "responses" | "generateContent";
 
 interface Citation {
   title: string;
   url?: string; // optional — compact mode strips Google groundingChunk URIs
 }
 
-interface ProviderResult {
+interface Result {
   answer: string;
-  queries: string[];     // search queries the provider actually issued
-  citations: Citation[]; // sources the answer is grounded in
-  cost: number | null;   // dollars, from X-Opper-Cost
-  bytes: number;         // size of the upstream response body
+  queries: string[];
+  citations: Citation[];
+  cost: number | null;
+  bytes: number;
   ms: number;
   error?: string;
 }
 
-interface AskOptions {
+interface AskRequest {
+  model: string;
+  engine: Engine;
+  question: string;
   compact: boolean;
 }
 
-function compatHeaders(opts: AskOptions): Record<string, string> {
-  const headers: Record<string, string> = {
-    "Authorization": `Bearer ${OPPER_API_KEY}`,
-    "Content-Type": "application/json",
-  };
-  if (opts.compact) headers["X-Opper-Compact-Response"] = "true";
-  return headers;
+// ---------------------------------------------------------------------------
+// Endpoint + request derivation
+// ---------------------------------------------------------------------------
+
+function endpointFor(model: string): { kind: EndpointKind; url: string } {
+  if (model.startsWith("anthropic/")) {
+    return { kind: "messages", url: `${OPPER_BASE_URL}/v3/compat/v1/messages` };
+  }
+  if (model.startsWith("openai/")) {
+    return { kind: "responses", url: `${OPPER_BASE_URL}/v3/compat/responses` };
+  }
+  if (model.startsWith("gemini") || model.startsWith("vertexai/gemini")) {
+    return {
+      kind: "generateContent",
+      // The model id can contain '/', which is part of the catalog slug
+      // (gemini/gemini-2.5-flash, vertexai/gemini-2.5-flash). The Go
+      // handler's wildcard route preserves it verbatim, so do NOT
+      // encodeURIComponent the slashes — only the action separator.
+      url: `${OPPER_BASE_URL}/v3/compat/v1beta/models/${model}:generateContent`,
+    };
+  }
+  throw new Error(`unsupported model prefix: ${model}`);
 }
 
-// ---------------------------------------------------------------------------
-// Anthropic — POST /v3/compat/v1/messages with web_search_20250305
-//
-// Response shape (post phase-2):
-//   content: [
-//     { type:"server_tool_use", name:"web_search", input:{query} },
-//     { type:"web_search_tool_result", content:[{type:"web_search_result", url, title, ...}] },
-//     { type:"text", text, citations?:[{type:"web_search_result_location", url, title, cited_text, ...}] },
-//     ...
-//   ]
-// ---------------------------------------------------------------------------
+function toolBlockFor(kind: EndpointKind, engine: Engine): unknown {
+  if (engine === "native") {
+    // The original demo path — provider's own server-tool entry. Each
+    // compat endpoint round-trips this verbatim to the upstream.
+    switch (kind) {
+      case "messages":        return { type: "web_search_20250305", name: "web_search", max_uses: 3 };
+      case "responses":       return { type: "web_search" };
+      case "generateContent": return { googleSearch: {} };
+    }
+  }
+  // For every non-native engine, the canonical Opper entry carries the
+  // selector. The server's resolver routes it: auto → native when the
+  // model declares server_tools.web_search=native and the endpoint matches,
+  // opper/jina/exa → server-side agentic loop with the named backend.
+  return { type: "opper:web_search", engine };
+}
 
-async function askAnthropic(question: string, opts: AskOptions): Promise<ProviderResult> {
-  const started = Date.now();
-  try {
-    const res = await fetch(`${OPPER_BASE_URL}/v3/compat/v1/messages`, {
-      method: "POST",
-      headers: compatHeaders(opts),
-      body: JSON.stringify({
-        model: ANTHROPIC_MODEL,
+function buildBody(kind: EndpointKind, model: string, question: string, tool: unknown): unknown {
+  switch (kind) {
+    case "messages":
+      return {
+        model,
         max_tokens: 1024,
         messages: [{ role: "user", content: question }],
-        tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 3 }],
-      }),
-    });
-    const cost = parseCostHeader(res.headers);
-    const raw = await res.text();
-    const body = JSON.parse(raw) as any;
-    if (!res.ok) throw new Error(body?.error?.message || `HTTP ${res.status}`);
-
-    let answer = "";
-    const queries: string[] = [];
-    const citations: Citation[] = [];
-
-    for (const block of body.content || []) {
-      if (block.type === "text") {
-        answer += block.text || "";
-        for (const c of block.citations || []) {
-          if (c.url) citations.push({ title: c.title || c.url, url: c.url });
-        }
-      } else if (block.type === "server_tool_use" && block.name === "web_search") {
-        const q = block.input?.query;
-        if (typeof q === "string") queries.push(q);
-      }
-    }
-    return { answer, queries, citations: dedupeCitations(citations), cost, bytes: raw.length, ms: Date.now() - started };
-  } catch (err: any) {
-    return { answer: "", queries: [], citations: [], cost: null, bytes: 0, ms: Date.now() - started, error: err.message };
+        tools: [tool],
+      };
+    case "responses":
+      return {
+        model,
+        input: question,
+        tools: [tool],
+        max_output_tokens: 1024,
+      };
+    case "generateContent":
+      // model is in the URL, not the body
+      return {
+        contents: [{ role: "user", parts: [{ text: question }] }],
+        tools: [tool],
+      };
   }
 }
 
 // ---------------------------------------------------------------------------
-// OpenAI — POST /v3/compat/responses with {type:"web_search"}
+// Response parsing — one per endpoint kind, engine-agnostic
 //
-// Response shape (post phase-2):
-//   output: [
-//     { type:"web_search_call", action:{type:"search", queries:[...]} },
-//     { type:"message", content:[{type:"output_text", text, annotations:[
-//         { type:"url_citation", url, title, start_index, end_index }
-//       ]}] },
-//   ]
+// The opper route synthesizes native-shape blocks on responses
+// (synthesizeAnthropicWebSearchBlocks etc. in the Go handlers), so the
+// same parser works regardless of which engine ran. The X-Opper-Cost
+// header diverges across engines (native = upstream surcharge, opper-
+// route = Opper's search-backend rate), which is the demo's point.
 // ---------------------------------------------------------------------------
 
-async function askOpenAI(question: string, opts: AskOptions): Promise<ProviderResult> {
-  const started = Date.now();
-  try {
-    const res = await fetch(`${OPPER_BASE_URL}/v3/compat/responses`, {
-      method: "POST",
-      headers: compatHeaders(opts),
-      body: JSON.stringify({
-        model: OPENAI_MODEL,
-        input: question,
-        tools: [{ type: "web_search" }],
-      }),
-    });
-    const cost = parseCostHeader(res.headers);
-    const raw = await res.text();
-    const body = JSON.parse(raw) as any;
-    if (!res.ok) throw new Error(body?.error?.message || `HTTP ${res.status}`);
+interface Parsed {
+  answer: string;
+  queries: string[];
+  citations: Citation[];
+}
 
-    let answer = "";
-    const queries: string[] = [];
-    const citations: Citation[] = [];
+function parseMessages(body: any): Parsed {
+  let answer = "";
+  const queries: string[] = [];
+  const citations: Citation[] = [];
 
-    for (const item of body.output || []) {
-      if (item.type === "web_search_call") {
-        const qs = item.action?.queries;
-        if (Array.isArray(qs)) for (const q of qs) if (typeof q === "string") queries.push(q);
-      } else if (item.type === "message" && Array.isArray(item.content)) {
-        for (const part of item.content) {
-          if (part.type === "output_text") {
-            answer += part.text || "";
-            for (const a of part.annotations || []) {
-              if (a.type === "url_citation" && a.url) {
-                citations.push({ title: a.title || a.url, url: a.url });
-              }
+  for (const block of body?.content || []) {
+    if (block.type === "text") {
+      answer += block.text || "";
+      for (const c of block.citations || []) {
+        if (c.url) citations.push({ title: c.title || c.url, url: c.url });
+      }
+    } else if (block.type === "server_tool_use" && block.name === "web_search") {
+      const q = block.input?.query;
+      if (typeof q === "string") queries.push(q);
+    } else if (block.type === "tool_use" && block.name === "opper_web_search") {
+      // Opper route emits a function tool call when the loop hits
+      // max_tokens / max_uses before reaching a final text turn. Surface
+      // the attempted query so the panel still shows the search ran.
+      const q = block.input?.query;
+      if (typeof q === "string") queries.push(q);
+    }
+  }
+  return { answer, queries, citations };
+}
+
+function parseResponses(body: any): Parsed {
+  let answer = "";
+  const queries: string[] = [];
+  const citations: Citation[] = [];
+
+  for (const item of body?.output || []) {
+    if (item.type === "web_search_call") {
+      // Both shapes: action.queries (array, native multi-query call) and
+      // action.query (scalar, per-search emitted by some routes).
+      const qs = item.action?.queries;
+      const q = item.action?.query;
+      if (Array.isArray(qs)) for (const qq of qs) if (typeof qq === "string") queries.push(qq);
+      else if (typeof q === "string") queries.push(q);
+    } else if (item.type === "message" && Array.isArray(item.content)) {
+      for (const part of item.content) {
+        if (part.type === "output_text") {
+          answer += part.text || "";
+          for (const a of part.annotations || []) {
+            if (a.type === "url_citation" && a.url) {
+              citations.push({ title: a.title || a.url, url: a.url });
             }
           }
         }
       }
     }
-    return { answer, queries, citations: dedupeCitations(citations), cost, bytes: raw.length, ms: Date.now() - started };
-  } catch (err: any) {
-    return { answer: "", queries: [], citations: [], cost: null, bytes: 0, ms: Date.now() - started, error: err.message };
   }
+  return { answer, queries, citations };
 }
 
+function parseGenerateContent(body: any): Parsed {
+  const candidate = body?.candidates?.[0];
+  const answer = (candidate?.content?.parts || [])
+    .map((p: any) => p.text || "")
+    .join("");
+  const gm = candidate?.groundingMetadata || {};
+  const queries: string[] = Array.isArray(gm.webSearchQueries)
+    ? gm.webSearchQueries.filter((q: any) => typeof q === "string")
+    : [];
+  const citations: Citation[] = [];
+  for (const chunk of gm.groundingChunks || []) {
+    const web = chunk?.web;
+    if (!web) continue;
+    const title = web.title || web.uri;
+    if (!title) continue;
+    citations.push(web.uri ? { title, url: web.uri } : { title });
+  }
+  return { answer, queries, citations };
+}
+
+const PARSERS: Record<EndpointKind, (body: any) => Parsed> = {
+  messages: parseMessages,
+  responses: parseResponses,
+  generateContent: parseGenerateContent,
+};
+
 // ---------------------------------------------------------------------------
-// Google — POST /v3/compat/v1beta/models/{model}:generateContent with googleSearch
-//
-// Response shape (post phase-2):
-//   candidates: [{
-//     content: { parts: [{text}, ...] },
-//     groundingMetadata: {
-//       webSearchQueries: [...],
-//       groundingChunks: [{web:{uri, title}}, ...],
-//       searchEntryPoint: {...},
-//     }
-//   }]
+// One dispatch
 // ---------------------------------------------------------------------------
 
-async function askGoogle(question: string, opts: AskOptions): Promise<ProviderResult> {
+async function ask(req: AskRequest): Promise<Result> {
   const started = Date.now();
   try {
-    const url = `${OPPER_BASE_URL}/v3/compat/v1beta/models/${encodeURIComponent(GOOGLE_MODEL)}:generateContent`;
+    const { kind, url } = endpointFor(req.model);
+    const headers: Record<string, string> = {
+      "Authorization": `Bearer ${OPPER_API_KEY}`,
+      "Content-Type": "application/json",
+    };
+    if (req.compact) headers["X-Opper-Compact-Response"] = "true";
+
+    const tool = toolBlockFor(kind, req.engine);
+    const body = buildBody(kind, req.model, req.question, tool);
+
     const res = await fetch(url, {
       method: "POST",
-      headers: compatHeaders(opts),
-      body: JSON.stringify({
-        contents: [{ role: "user", parts: [{ text: question }] }],
-        tools: [{ googleSearch: {} }],
-      }),
+      headers,
+      body: JSON.stringify(body),
     });
     const cost = parseCostHeader(res.headers);
     const raw = await res.text();
-    const body = JSON.parse(raw) as any;
-    if (!res.ok) throw new Error(body?.error?.message || `HTTP ${res.status}`);
+    let json: any;
+    try { json = JSON.parse(raw); } catch { json = {}; }
 
-    const candidate = body.candidates?.[0];
-    const answer = (candidate?.content?.parts || [])
-      .map((p: any) => p.text || "")
-      .join("");
-    const gm = candidate?.groundingMetadata || {};
-    const queries: string[] = Array.isArray(gm.webSearchQueries) ? gm.webSearchQueries.filter((q: any) => typeof q === "string") : [];
-    const citations: Citation[] = [];
-    for (const chunk of gm.groundingChunks || []) {
-      const web = chunk.web;
-      if (!web) continue;
-      const title = web.title || web.uri;
-      if (!title) continue;
-      citations.push(web.uri ? { title, url: web.uri } : { title });
+    if (!res.ok) {
+      const message =
+        json?.error?.message ||
+        (typeof json?.error === "string" ? json.error : null) ||
+        `HTTP ${res.status}`;
+      return {
+        answer: "",
+        queries: [],
+        citations: [],
+        cost,
+        bytes: raw.length,
+        ms: Date.now() - started,
+        error: message,
+      };
     }
-    return { answer, queries, citations: dedupeCitations(citations), cost, bytes: raw.length, ms: Date.now() - started };
+
+    const parsed = PARSERS[kind](json);
+    return {
+      ...parsed,
+      citations: dedupeCitations(parsed.citations),
+      cost,
+      bytes: raw.length,
+      ms: Date.now() - started,
+    };
   } catch (err: any) {
-    return { answer: "", queries: [], citations: [], cost: null, bytes: 0, ms: Date.now() - started, error: err.message };
+    return {
+      answer: "", queries: [], citations: [],
+      cost: null, bytes: 0, ms: Date.now() - started,
+      error: err?.message || String(err),
+    };
   }
 }
 
@@ -252,29 +324,41 @@ function dedupeCitations(citations: Citation[]): Citation[] {
 }
 
 // ---------------------------------------------------------------------------
-// Express plumbing
+// Express
 // ---------------------------------------------------------------------------
 
 const app = express();
 app.use(express.json());
 app.use(express.static(join(__dirname, "public")));
 
-// One endpoint per provider so the browser can fire all three in parallel
-// and paint each column the moment its provider finishes — no waiting on
-// the slowest. The shape of every response is the same ProviderResult JSON.
-const ASKERS: Record<string, (q: string, o: AskOptions) => Promise<ProviderResult>> = {
-  anthropic: askAnthropic,
-  openai: askOpenAI,
-  google: askGoogle,
-};
+// The page reads this on load to render the right model labels in the
+// preset switcher without hardcoding env values in the HTML.
+app.get("/api/defaults", (_req, res) => {
+  res.json({
+    anthropic: ANTHROPIC_MODEL,
+    openai: OPENAI_MODEL,
+    google: GOOGLE_MODEL,
+    engines: ["native", "auto", "opper", "jina", "exa"],
+  });
+});
 
-app.post("/api/ask/:provider", async (req, res) => {
-  const asker = ASKERS[req.params.provider];
-  if (!asker) return res.status(404).json({ error: `unknown provider: ${req.params.provider}` });
+const VALID_ENGINES: Engine[] = ["native", "auto", "opper", "jina", "exa"];
+
+app.post("/api/ask", async (req, res) => {
+  const model: string = (req.body?.model || "").toString().trim();
+  const engine: string = (req.body?.engine || "native").toString().trim();
   const question: string = (req.body?.question || "").toString().trim();
+  if (!model)    return res.status(400).json({ error: "model is required" });
   if (!question) return res.status(400).json({ error: "question is required" });
-  const opts: AskOptions = { compact: !!req.body?.compact };
-  res.json(await asker(question, opts));
+  if (!VALID_ENGINES.includes(engine as Engine)) {
+    return res.status(400).json({ error: `unknown engine: ${engine}` });
+  }
+  res.json(await ask({
+    model,
+    engine: engine as Engine,
+    question,
+    compact: !!req.body?.compact,
+  }));
 });
 
 const PORT = await findPort(PREFERRED_PORT);


### PR DESCRIPTION
## Summary

Reworks the `server-tools-compare` example so the same demo can show the original 3-provider native comparison **and** model-× -engine comparisons side by side, driven by a preset switcher at the top of the page.

## Presets

- **Providers (native)** — default. Three panels, one per provider, each sending its own native server-tool block (`web_search_20250305`, OpenAI `web_search`, Google `googleSearch`). Identical UX to before.
- **Claude — all engines**, **GPT-5.5 — all engines**, **Gemini — all engines** — five panels for the same model, one per engine selector (`native`, `auto`, `opper`, `jina`, `exa`).

The engine presets show the cost + latency + answer divergence between calling a provider's native server tool, letting Opper auto-route, and forcing the server-side agentic loop with different search backends — exactly the comparison the new per-model `server_tools` routing (opper PR #2768) enables.

## What changed

- **`server.ts`** — one generic `ask({model, engine, question, compact})` dispatch replaces the three per-provider askers. The endpoint is derived from the model prefix (`anthropic/` → `/v1/messages`, `openai/` → `/responses`, `gemini`/`vertexai/gemini` → `/v1beta/models/{model}:generateContent`). The tool block is the provider's native shape for `engine=native`, or `{type:"opper:web_search", engine:<engine>}` for everything else. One parser per endpoint kind — the opper route synthesizes provider-native blocks on the wire, so the parsers stay uniform.
- **`public/index.html`** — preset tabs + dynamic panel grid (CSS `grid-template-columns: repeat(auto-fit, minmax(280px, 1fr))` adapts cleanly from 3 panels to 5). Engine chip on each card header so it's obvious which selector ran.
- **`README.md`** — updated to describe the four presets, the engine selector semantics, and the cost-divergence point.

## Test plan

- [x] `tsx server.ts` boots; `GET /api/defaults` returns model labels.
- [x] Live matrix through `/api/ask` against local Opper stack (all 8 returned 200 with non-empty answers):
  - anthropic/claude-sonnet-4-6 × {native, auto, opper}
  - openai/gpt-5.5 × {native, auto}
  - openai/gpt-4o-mini × auto (the bug-fix case — auto correctly falls back to opper-route, was 502 before #2768)
  - gemini-2.5-flash × {native, auto}
- [x] Cost diverges between native and opper-route engines as expected (e.g. claude native $0.020, claude opper $0.073 — 4 searches via Jina vs 1 via Anthropic).
- [ ] Visual browser smoke (skipped — wire-level matrix above covers the dispatch surface).