### PR TITLE
Add live-translate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Examples and guides for building with [Opper](https://opper.ai). PRs are welcome
 | [content-analyzer](examples/content-analyzer/) | TypeScript | Parallel analysis, embeddings, knowledge base, streaming, text-to-speech, tracing |
 | [chatbot-openresponses](examples/chatbot-openresponses/) | TypeScript | OpenResponses endpoint via raw fetch(), agentic tool loop, image generation, TTS, web UI |
 | [brainstorm-time](examples/brainstorm-time/) | TypeScript | Realtime voice brainstorming — browser-direct WebSocket via ephemeral tickets, mic input, image generation, web search, live idea board |
+| [live-translate](examples/live-translate/) | TypeScript | Realtime speech-to-speech translation — browser-direct WebSocket via ephemeral tickets, model + target language locked on the ticket, live captions (Gemini 3.5 Live Translate) |
 | [opper-tour](examples/opper-tour/) | TypeScript | Realtime voice tour guide that drives a server-side Playwright Chromium and streams screenshots back to the browser — pre-baked Opper site map, URL allowlist, per-session BrowserContext |
 | [server-tools-compare](examples/server-tools-compare/) | TypeScript | Side-by-side web search: same question fanned out to Anthropic, OpenAI, and Google server-side tools through Opper compat — answer, cost, latency per provider |
 | [login-with-opper-web](examples/login-with-opper-web/) | JavaScript | OAuth login flow, token exchange, inference — Express web app with branded button |

--- a/examples/live-translate/README.md
+++ b/examples/live-translate/README.md
@@ -1,0 +1,60 @@
+# Live Translate
+
+Real-time **speech-to-speech translation** in the browser. You speak in any language; the model speaks it back in the language you picked — a few seconds behind, continuously, the way a human interpreter works. The browser talks **directly to Opper** over WebSocket, authenticated with a short-lived ephemeral ticket. The Node server only mints tickets — it never sits on the audio path.
+
+Powered by Opper's Realtime API and **Gemini 3.5 Live Translate** (`gemini/gemini-3.5-live-translate-preview`), which auto-detects the source language across 70+ languages and preserves the speaker's intonation and pacing.
+
+What it shows:
+
+- **Speech-to-speech translation** over the Realtime WebSocket — audio in, translated audio out, no turns to manage. The model streams continuously.
+- **Browser-direct WebSocket** authenticated with a single-use ticket carried in the `Sec-WebSocket-Protocol: opper-ticket.<secret>` subprotocol header — the API key never appears in the browser, URLs, or access logs.
+- **Pre-binding** — the model **and the target language** are locked onto the ticket at mint time (`locked_fields`). A leaked ticket can only run the exact translation you authorized; it cannot switch models or change the target language.
+- **Live captions** — the source-language transcript of what was heard, and the streaming translated text, rendered alongside the audio.
+
+## Flow
+
+1. Browser POSTs `/api/realtime/session` with the chosen target language.
+2. Node POSTs `/v3/realtime-sessions` to Opper with the API key in `Authorization`, binding `model` + `translation_target_language` onto the ticket. Opper returns a `client_secret` and an expiry.
+3. Browser opens `wss://api.opper.ai/v3/realtime` directly, carrying the ticket in the subprotocol header, and sends `session.start` with an empty config (the locked fields are filled server-side).
+4. Browser streams microphone audio (`audio.append`); Opper streams back translated audio (`audio.delta`) plus `transcript.committed` (what you said) and `text.delta` (the translation).
+
+The browser **never sees the API key**.
+
+## Setup
+
+```bash
+npm install
+```
+
+## Run
+
+```bash
+OPPER_API_KEY=your-key npm start
+```
+
+Open [http://localhost:3000](http://localhost:3000), pick a target language, and start talking.
+
+> **Note — model availability.** This demo needs `gemini/gemini-3.5-live-translate-preview` on the Opper deployment you point at. If it isn't in production yet, run the branch that adds it on a local stack and set `OPPER_BASE_URL` (and, if needed, `OPPER_WS_BASE`) to that stack.
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `OPPER_API_KEY` | (required) | Project-scoped runtime API key |
+| `OPPER_BASE_URL` | `https://api.opper.ai` | Override for local development |
+| `OPPER_WS_BASE` | derived from `OPPER_BASE_URL` | Public WebSocket origin |
+| `PORT` | `3000` | Server port |
+
+### Target-language allowlist
+
+The dropdown is populated from `TARGET_LANGUAGES` in `server.ts`. The browser POSTs its choice; the server validates against this list before binding it onto the ticket and rejects anything off-list with `400`. The model supports 70+ languages — add more rows to widen the menu. That array is the policy boundary in one place.
+
+## Notes on the model
+
+- **Continuous, not turn-based.** Live Translate streams audio without `turnComplete` boundaries, so there's nothing to "send" — just keep the mic open. Barge-in (the speaker talking over the playback) is surfaced as `speech.started`, which clears the playback queue.
+- **Captions are best-effort.** The translated-text transcript is emitted sparsely and can be partial — the audio is the primary output. The source transcript confirms what the model heard.
+- **One target per session.** A session translates everything into a single target language. For a two-way conversation, mint a second session in the opposite direction.
+
+## Architecture notes
+
+Browsers cannot set an `Authorization` header on `new WebSocket(...)`, which is the whole reason the ephemeral-ticket pattern exists — see the [Realtime voice guide](https://docs.opper.ai/capabilities/realtime) for the security model and lifecycle. The alternative is a Node WS proxy that forwards frames bidirectionally (heavier backend, full server-side observability); the ticket pattern is the recommended default and what this example uses.

--- a/examples/live-translate/README.md
+++ b/examples/live-translate/README.md
@@ -9,7 +9,7 @@ What it shows:
 - **Speech-to-speech translation** over the Realtime WebSocket — audio in, translated audio out, no turns to manage. The model streams continuously.
 - **Browser-direct WebSocket** authenticated with a single-use ticket carried in the `Sec-WebSocket-Protocol: opper-ticket.<secret>` subprotocol header — the API key never appears in the browser, URLs, or access logs.
 - **Pre-binding** — the model **and the target language** are locked onto the ticket at mint time (`locked_fields`). A leaked ticket can only run the exact translation you authorized; it cannot switch models or change the target language.
-- **Live captions** — the source-language transcript of what was heard, and the streaming translated text, rendered alongside the audio.
+- **Live captions** — the streaming translated text, rendered as continuous interpretation alongside the audio. (The source-language transcript also arrives on the wire as `transcript.committed`; the UI uses it only as an utterance boundary and doesn't render it, so the translation reads as one flowing stream.)
 
 ## Flow
 
@@ -52,7 +52,7 @@ The dropdown is populated from `TARGET_LANGUAGES` in `server.ts`. The browser PO
 ## Notes on the model
 
 - **Continuous, not turn-based.** Live Translate streams audio without `turnComplete` boundaries, so there's nothing to "send" — just keep the mic open. Barge-in (the speaker talking over the playback) is surfaced as `speech.started`, which clears the playback queue.
-- **Captions are best-effort.** The translated-text transcript is emitted sparsely and can be partial — the audio is the primary output. The source transcript confirms what the model heard.
+- **Captions are best-effort.** The translated-text transcript is emitted sparsely and can be partial — the audio is the primary output. The model generates translated speech directly (speech-to-speech); the transcript is a separate ASR pass layered on top, which is why it can lag or drop.
 - **One target per session.** A session translates everything into a single target language. For a two-way conversation, mint a second session in the opposite direction.
 
 ## Architecture notes

--- a/examples/live-translate/package.json
+++ b/examples/live-translate/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "live-translate",
+  "version": "0.1.0",
+  "description": "Real-time speech-to-speech translation — browser-direct WebSocket via ephemeral tickets, powered by Opper's Realtime API and Gemini 3.5 Live Translate",
+  "type": "module",
+  "scripts": {
+    "start": "tsx server.ts"
+  },
+  "dependencies": {
+    "express": "^5.1.0",
+    "opperai": "^4.0.0-beta.2"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "tsx": "^4.0.0"
+  }
+}

--- a/examples/live-translate/public/index.html
+++ b/examples/live-translate/public/index.html
@@ -1,0 +1,446 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Live Translate</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Wix+Madefor+Display:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --background: oklch(1 0 0);
+      --foreground: oklch(0.2938 0.0414 248.11);
+      --card: oklch(1 0 0);
+      --muted: oklch(0.97 0 0);
+      --muted-foreground: oklch(0.45 0 0);
+      --border: oklch(0.922 0 0);
+      --primary: oklch(0.205 0 0);
+      --primary-foreground: oklch(0.985 0 0);
+      --ring: oklch(0.708 0 0);
+      --radius: 0.625rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --background: oklch(0.252 0 102.07);
+        --foreground: oklch(0.9881 0 102.07);
+        --card: oklch(0.23 0 0);
+        --muted: oklch(0.30 0 0);
+        --muted-foreground: oklch(0.72 0 0);
+        --border: oklch(0.35 0 0);
+        --primary: oklch(0.9881 0 102.07);
+        --primary-foreground: oklch(0.252 0 102.07);
+        --ring: oklch(0.556 0 0);
+      }
+    }
+    html, body { background: var(--background); color: var(--foreground); }
+    body { font-family: 'Wix Madefor Display', system-ui, -apple-system, sans-serif; }
+    .feed::-webkit-scrollbar { width: 6px; }
+    .feed::-webkit-scrollbar-track { background: transparent; }
+    .feed::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+    select, button { font-family: inherit; }
+    select { background-image: none; }
+    .field {
+      background: var(--card); color: var(--foreground);
+      border: 1px solid var(--border); border-radius: var(--radius);
+      transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .field:hover { border-color: oklch(from var(--border) calc(l - 0.05) c h); }
+    .field:focus-visible { outline: none; border-color: var(--ring); box-shadow: 0 0 0 3px oklch(from var(--ring) l c h / 0.25); }
+    .btn-primary {
+      background: var(--primary); color: var(--primary-foreground);
+      border-radius: var(--radius);
+      transition: opacity 150ms ease, transform 80ms ease;
+    }
+    .btn-primary:hover { opacity: 0.9; }
+    .btn-primary:active { transform: translateY(1px); }
+    .btn-ghost {
+      background: var(--muted); color: var(--muted-foreground);
+      border-radius: var(--radius);
+      transition: background-color 150ms ease, color 150ms ease;
+    }
+    .btn-ghost:hover { color: var(--foreground); }
+    .card { background: var(--card); border: 1px solid var(--border); border-radius: var(--radius); }
+    .recording { animation: recPulse 1.6s ease-in-out infinite; }
+    @keyframes recPulse {
+      0%, 100% { box-shadow: 0 0 0 0 oklch(from var(--foreground) l c h / 0.18); }
+      50%      { box-shadow: 0 0 0 10px oklch(from var(--foreground) l c h / 0); }
+    }
+    .status-dot { width: 6px; height: 6px; border-radius: 999px; background: var(--muted-foreground); display: inline-block; }
+    .status-dot.live { background: oklch(0.65 0.18 145); box-shadow: 0 0 0 3px oklch(0.65 0.18 145 / 0.18); }
+    @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+    .bubble { border-radius: var(--radius); padding: 0.6rem 0.85rem; max-width: 90%; line-height: 1.45; animation: fadeIn 180ms ease-out; }
+    .bubble-src { background: var(--muted); color: var(--muted-foreground); align-self: flex-start; }
+    .bubble-xlt { background: var(--card); color: var(--foreground); align-self: flex-end; border: 1px solid var(--border); }
+    .tag { font-size: 0.68rem; font-weight: 600; letter-spacing: 0.02em; text-transform: uppercase; opacity: 0.7; margin-bottom: 0.15rem; display: block; }
+  </style>
+</head>
+<body class="min-h-screen">
+
+  <!-- Landing -->
+  <div id="landing" class="min-h-screen flex items-center justify-center p-6">
+    <div class="card w-full max-w-md p-8">
+      <div class="flex items-center gap-3 mb-1">
+        <span class="text-3xl">🗣️</span>
+        <h1 class="text-2xl font-bold">Live Translate</h1>
+      </div>
+      <p class="text-sm mb-6" style="color: var(--muted-foreground)">
+        Speak in <strong>any language</strong> — hear it spoken back, instantly, in the language you choose.
+        Source language is detected automatically.
+      </p>
+
+      <label class="block text-sm font-medium mb-2">Translate into</label>
+      <select id="targetSelect" class="field w-full px-3 py-2.5 mb-5"></select>
+
+      <button id="startBtn" class="btn-primary w-full py-3 font-semibold">
+        Start translating
+      </button>
+
+      <p class="text-xs mt-4 leading-relaxed" style="color: var(--muted-foreground)">
+        The browser connects straight to Opper over WebSocket, authenticated with a single-use
+        ephemeral ticket. The model and target language are locked onto the ticket at mint time —
+        your API key never reaches the browser.
+      </p>
+    </div>
+  </div>
+
+  <!-- Session -->
+  <div id="session" class="hidden min-h-screen flex flex-col max-w-2xl mx-auto p-4">
+    <header class="flex items-center justify-between py-3">
+      <div class="flex items-center gap-2">
+        <span class="text-xl">🗣️</span>
+        <div>
+          <div class="font-semibold leading-tight">Live Translate</div>
+          <div class="text-xs flex items-center gap-1.5" style="color: var(--muted-foreground)">
+            <span id="statusDot" class="status-dot"></span>
+            <span id="statusLine">Connecting…</span>
+          </div>
+        </div>
+      </div>
+      <div class="flex items-center gap-2">
+        <span id="targetBadge" class="text-xs px-2.5 py-1 rounded-full" style="background: var(--muted); color: var(--muted-foreground)"></span>
+        <button id="endBtn" class="btn-ghost text-sm px-3 py-1.5">End</button>
+      </div>
+    </header>
+
+    <div id="feed" class="feed flex-1 overflow-y-auto flex flex-col gap-3 py-4"></div>
+
+    <footer class="py-4 flex flex-col items-center gap-2">
+      <button id="micBtn" class="btn-ghost w-16 h-16 rounded-full flex items-center justify-center text-2xl" title="Toggle microphone (Space)">
+        🎙️
+      </button>
+      <div class="text-xs" style="color: var(--muted-foreground)">
+        <span id="micHint">Tap the mic and start speaking</span> · <kbd class="px-1">Space</kbd> toggles
+      </div>
+    </footer>
+  </div>
+
+  <script>
+    // ── DOM ──────────────────────────────────────────────────────────────
+    const landing = document.getElementById("landing");
+    const session = document.getElementById("session");
+    const targetSelect = document.getElementById("targetSelect");
+    const startBtn = document.getElementById("startBtn");
+    const endBtn = document.getElementById("endBtn");
+    const micBtn = document.getElementById("micBtn");
+    const micHint = document.getElementById("micHint");
+    const feed = document.getElementById("feed");
+    const statusLine = document.getElementById("statusLine");
+    const statusDot = document.getElementById("statusDot");
+    const targetBadge = document.getElementById("targetBadge");
+
+    // ── State ────────────────────────────────────────────────────────────
+    let ws = null;
+    let audioContext = null;
+    let micStream = null, micSource = null, micProcessor = null, micActive = false;
+    let playbackQueue = [], isPlaying = false, currentSource = null;
+    let inputSampleRate = 16000;   // mic capture rate (Gemini Live wants 16k)
+    let outputSampleRate = 24000;  // playback rate (Gemini Live emits 24k)
+    let targetLabel = "";
+    let curXlt = null;             // the in-progress translation bubble
+
+    // ── Boot: load the language menu ─────────────────────────────────────
+    (async () => {
+      try {
+        const cfg = await (await fetch("/api/config")).json();
+        for (const l of cfg.languages) {
+          const o = document.createElement("option");
+          o.value = l.code; o.textContent = l.label;
+          if (l.code === cfg.defaultTarget) o.selected = true;
+          targetSelect.appendChild(o);
+        }
+      } catch (e) {
+        statusLine.textContent = "Failed to load config";
+      }
+    })();
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+    function setStatus(text, live) {
+      statusLine.textContent = text;
+      if (live !== undefined) statusDot.classList.toggle("live", !!live);
+    }
+
+    function uint8ToBase64(bytes) {
+      let bin = "";
+      const chunk = 0x8000;
+      for (let i = 0; i < bytes.length; i += chunk) {
+        bin += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
+      }
+      return btoa(bin);
+    }
+
+    // Linear-interpolation resample. Mic runs at the AudioContext's native
+    // rate (often 48k); the model wants 16k. Playback is the reverse.
+    function resample(f32, fromRate, toRate) {
+      if (fromRate === toRate) return f32;
+      const ratio = fromRate / toRate;
+      const len = Math.round(f32.length / ratio);
+      const out = new Float32Array(len);
+      for (let i = 0; i < len; i++) {
+        const idx = i * ratio;
+        const lo = Math.floor(idx);
+        const hi = Math.min(lo + 1, f32.length - 1);
+        const frac = idx - lo;
+        out[i] = f32[lo] * (1 - frac) + f32[hi] * frac;
+      }
+      return out;
+    }
+
+    function addSource(text) {
+      const el = document.createElement("div");
+      el.className = "bubble bubble-src";
+      el.innerHTML = `<span class="tag">🌐 heard</span>${escapeHtml(text)}`;
+      feed.appendChild(el);
+      feed.scrollTop = feed.scrollHeight;
+    }
+
+    function appendXlt(delta) {
+      if (!curXlt) {
+        curXlt = document.createElement("div");
+        curXlt.className = "bubble bubble-xlt";
+        curXlt._text = "";
+        curXlt.innerHTML = `<span class="tag">🔊 ${escapeHtml(targetLabel)}</span><span class="body"></span>`;
+        feed.appendChild(curXlt);
+      }
+      curXlt._text += delta;
+      curXlt.querySelector(".body").textContent = curXlt._text;
+      feed.scrollTop = feed.scrollHeight;
+    }
+
+    function finalizeXlt() { curXlt = null; }
+
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>"']/g, (c) => (
+        { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
+      ));
+    }
+
+    // ── Playback ─────────────────────────────────────────────────────────
+    function playAudioChunk(b64) {
+      playbackQueue.push(b64);
+      if (!isPlaying) drainPlayback();
+    }
+    async function drainPlayback() {
+      if (playbackQueue.length === 0) { isPlaying = false; return; }
+      isPlaying = true;
+      const b64 = playbackQueue.shift();
+      try {
+        if (!audioContext) audioContext = new AudioContext();
+        if (audioContext.state === "suspended") await audioContext.resume();
+        const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+        const pcm16 = new Int16Array(bytes.buffer);
+        const f32 = new Float32Array(pcm16.length);
+        for (let i = 0; i < pcm16.length; i++) f32[i] = pcm16[i] / 32768;
+        const buf = audioContext.createBuffer(1, f32.length, outputSampleRate);
+        buf.copyToChannel(f32, 0);
+        const src = audioContext.createBufferSource();
+        src.buffer = buf;
+        src.connect(audioContext.destination);
+        currentSource = src;
+        src.onended = () => { currentSource = null; drainPlayback(); };
+        src.start();
+      } catch (e) {
+        console.warn("playback error:", e);
+        drainPlayback();
+      }
+    }
+    function stopPlayback() {
+      playbackQueue = [];
+      isPlaying = false;
+      if (currentSource) {
+        try { currentSource.onended = null; currentSource.stop(); } catch {}
+        currentSource = null;
+      }
+    }
+
+    // ── Mic ──────────────────────────────────────────────────────────────
+    async function toggleMic() { if (micActive) stopMic(); else await startMic(); }
+
+    async function startMic() {
+      try {
+        micStream = await navigator.mediaDevices.getUserMedia({
+          audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+        });
+        if (!audioContext) audioContext = new AudioContext();
+        if (audioContext.state === "suspended") await audioContext.resume();
+
+        const nativeRate = audioContext.sampleRate;
+        micSource = audioContext.createMediaStreamSource(micStream);
+        micProcessor = audioContext.createScriptProcessor(4096, 1, 1);
+
+        micProcessor.onaudioprocess = (e) => {
+          if (!micActive || !ws || ws.readyState !== WebSocket.OPEN) return;
+          const raw = e.inputBuffer.getChannelData(0);
+          const ds = resample(raw, nativeRate, inputSampleRate);
+          const pcm16 = new Int16Array(ds.length);
+          for (let i = 0; i < ds.length; i++) {
+            pcm16[i] = Math.max(-32768, Math.min(32767, Math.round(ds[i] * 32768)));
+          }
+          ws.send(JSON.stringify({ type: "audio.append", audio: uint8ToBase64(new Uint8Array(pcm16.buffer)) }));
+        };
+
+        micSource.connect(micProcessor);
+        micProcessor.connect(audioContext.destination);
+        micActive = true;
+        micBtn.classList.remove("btn-ghost");
+        micBtn.classList.add("btn-primary", "recording");
+        micHint.textContent = "Listening — speak naturally";
+        setStatus("Listening…", true);
+      } catch (err) {
+        console.error("mic error:", err);
+        setStatus("Microphone access denied");
+      }
+    }
+
+    function stopMic() {
+      micActive = false;
+      if (micProcessor) { micProcessor.disconnect(); micProcessor = null; }
+      if (micSource) { micSource.disconnect(); micSource = null; }
+      if (micStream) { micStream.getTracks().forEach(t => t.stop()); micStream = null; }
+      micBtn.classList.remove("btn-primary", "recording");
+      micBtn.classList.add("btn-ghost");
+      micHint.textContent = "Mic off — tap to resume";
+      setStatus("Paused", false);
+      if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: "audio.commit" }));
+    }
+
+    // ── Session lifecycle ────────────────────────────────────────────────
+    startBtn.addEventListener("click", startSession);
+    endBtn.addEventListener("click", endSession);
+    micBtn.addEventListener("click", toggleMic);
+    document.addEventListener("keydown", (e) => {
+      if (session.classList.contains("hidden")) return;
+      if (e.code === "Space") { e.preventDefault(); toggleMic(); }
+    });
+
+    async function startSession() {
+      const target = targetSelect.value;
+      startBtn.disabled = true;
+      startBtn.textContent = "Minting ticket…";
+      try {
+        // Step 1: mint a ticket via our backend. The API key stays server-side.
+        const resp = await fetch("/api/realtime/session", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ target }),
+        });
+        if (!resp.ok) throw new Error((await resp.json()).error || resp.statusText);
+        const ticket = await resp.json();
+        targetLabel = ticket.targetLabel || target;
+
+        landing.classList.add("hidden");
+        session.classList.remove("hidden");
+        feed.innerHTML = "";
+        targetBadge.textContent = `→ ${targetLabel}`;
+        setStatus("Connecting…");
+
+        // Step 2: open the realtime WS directly against Opper, carrying the
+        // ticket in the Sec-WebSocket-Protocol subprotocol (not the URL).
+        ws = new WebSocket(ticket.wsBaseUrl, [`opper-ticket.${ticket.clientSecret}`]);
+
+        ws.onopen = () => {
+          // Model + target language are bound on the ticket, so an empty
+          // config is enough — the server fills the locked fields.
+          ws.send(JSON.stringify({ type: "session.start", config: {} }));
+        };
+        ws.onmessage = (evt) => {
+          try { handleServerEvent(JSON.parse(evt.data)); }
+          catch (err) { console.warn("[ws] parse error:", err); }
+        };
+        ws.onclose = (e) => {
+          setStatus("Disconnected", false);
+          if (!e.wasClean) addSource("Connection lost.");
+        };
+        ws.onerror = () => setStatus("Connection error", false);
+      } catch (err) {
+        console.error(err);
+        setStatus("Failed to start: " + err.message);
+        landing.classList.remove("hidden");
+        session.classList.add("hidden");
+      } finally {
+        startBtn.disabled = false;
+        startBtn.textContent = "Start translating";
+      }
+    }
+
+    function handleServerEvent(msg) {
+      switch (msg.type || "") {
+        case "session.started":
+          inputSampleRate = msg.input_sample_rate || msg.sample_rate || 16000;
+          outputSampleRate = msg.output_sample_rate || 24000;
+          setStatus("Connected — start speaking", true);
+          startMic();
+          return;
+
+        case "audio.delta":
+          if (msg.audio) playAudioChunk(msg.audio);
+          return;
+
+        // Source-language transcript of what the speaker said.
+        case "transcript.committed":
+          if (msg.transcript) addSource(msg.transcript);
+          finalizeXlt(); // a new utterance heard → close the prior translation
+          return;
+
+        // Streaming translated text (the words the model is speaking).
+        case "text.delta":
+          if (msg.delta) appendXlt(msg.delta);
+          return;
+
+        // Barge-in: the speaker started talking over the playback.
+        case "speech.started":
+          stopPlayback();
+          finalizeXlt();
+          return;
+
+        case "response.completed":
+        case "response.done":
+          finalizeXlt();
+          return;
+
+        case "session.terminating":
+          setStatus(`Session ending: ${msg.error?.message || msg.error?.code || ""}`);
+          return;
+
+        case "error": {
+          const m = msg.message || msg.error?.message || msg.error || "unknown";
+          // Mid-turn artifacts are normal; don't surface them.
+          if (typeof m === "string" && /cancel|buffer too small/i.test(m)) return;
+          setStatus("Error: " + m);
+          return;
+        }
+      }
+    }
+
+    function endSession() {
+      if (ws) { ws.close(); ws = null; }
+      stopMic();
+      stopPlayback();
+      if (audioContext) { audioContext.close(); audioContext = null; }
+      curXlt = null;
+      session.classList.add("hidden");
+      landing.classList.remove("hidden");
+    }
+  </script>
+</body>
+</html>

--- a/examples/live-translate/public/index.html
+++ b/examples/live-translate/public/index.html
@@ -69,10 +69,19 @@
     .status-dot { width: 6px; height: 6px; border-radius: 999px; background: var(--muted-foreground); display: inline-block; }
     .status-dot.live { background: oklch(0.65 0.18 145); box-shadow: 0 0 0 3px oklch(0.65 0.18 145 / 0.18); }
     @keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
-    .bubble { border-radius: var(--radius); padding: 0.6rem 0.85rem; max-width: 90%; line-height: 1.45; animation: fadeIn 180ms ease-out; }
-    .bubble-src { background: var(--muted); color: var(--muted-foreground); align-self: flex-start; }
-    .bubble-xlt { background: var(--card); color: var(--foreground); align-self: flex-end; border: 1px solid var(--border); }
-    .tag { font-size: 0.68rem; font-weight: 600; letter-spacing: 0.02em; text-transform: uppercase; opacity: 0.7; margin-bottom: 0.15rem; display: block; }
+    /* Translated text reads as continuous interpretation: one flowing line
+       per utterance, the in-progress one slightly emphasized. */
+    .caption {
+      font-size: 1.35rem; line-height: 1.55; font-weight: 500;
+      color: var(--foreground);
+      animation: fadeIn 180ms ease-out;
+    }
+    .caption:not(.caption-live) { color: var(--muted-foreground); }
+    .caption-live::after {
+      content: "▌"; margin-left: 1px;
+      animation: caret 1s step-end infinite; opacity: 0.6;
+    }
+    @keyframes caret { 50% { opacity: 0; } }
   </style>
 </head>
 <body class="min-h-screen">
@@ -123,7 +132,10 @@
       </div>
     </header>
 
-    <div id="feed" class="feed flex-1 overflow-y-auto flex flex-col gap-3 py-4"></div>
+    <div id="feed" class="feed flex-1 overflow-y-auto flex flex-col gap-4 py-6"></div>
+    <div id="feedHint" class="flex-1 flex items-center justify-center text-center px-8" style="color: var(--muted-foreground)">
+      <p class="text-sm max-w-xs">Start speaking — the translation appears here, a few seconds behind, in <span id="hintTarget" class="font-medium"></span>.</p>
+    </div>
 
     <footer class="py-4 flex flex-col items-center gap-2">
       <button id="micBtn" class="btn-ghost w-16 h-16 rounded-full flex items-center justify-center text-2xl" title="Toggle microphone (Space)">
@@ -145,6 +157,8 @@
     const micBtn = document.getElementById("micBtn");
     const micHint = document.getElementById("micHint");
     const feed = document.getElementById("feed");
+    const feedHint = document.getElementById("feedHint");
+    const hintTarget = document.getElementById("hintTarget");
     const statusLine = document.getElementById("statusLine");
     const statusDot = document.getElementById("statusDot");
     const targetBadge = document.getElementById("targetBadge");
@@ -206,28 +220,33 @@
       return out;
     }
 
-    function addSource(text) {
-      const el = document.createElement("div");
-      el.className = "bubble bubble-src";
-      el.innerHTML = `<span class="tag">🌐 heard</span>${escapeHtml(text)}`;
-      feed.appendChild(el);
-      feed.scrollTop = feed.scrollHeight;
-    }
-
+    // The translated text streams into one rolling caption line. A new line
+    // starts only on an utterance boundary (the speaker finishes a thought),
+    // so the translation reads as continuous interpretation rather than
+    // paired "heard / translated" chat bubbles.
     function appendXlt(delta) {
       if (!curXlt) {
+        // First translation — swap the placeholder for the live feed.
+        if (!feedHint.classList.contains("hidden")) {
+          feedHint.classList.add("hidden");
+          feed.classList.remove("hidden");
+        }
         curXlt = document.createElement("div");
-        curXlt.className = "bubble bubble-xlt";
+        curXlt.className = "caption caption-live";
         curXlt._text = "";
-        curXlt.innerHTML = `<span class="tag">🔊 ${escapeHtml(targetLabel)}</span><span class="body"></span>`;
         feed.appendChild(curXlt);
       }
       curXlt._text += delta;
-      curXlt.querySelector(".body").textContent = curXlt._text;
+      curXlt.textContent = curXlt._text;
       feed.scrollTop = feed.scrollHeight;
     }
 
-    function finalizeXlt() { curXlt = null; }
+    // Close the current line so the next utterance's translation starts
+    // fresh. Drops the "live" styling once it's settled.
+    function finalizeXlt() {
+      if (curXlt) curXlt.classList.remove("caption-live");
+      curXlt = null;
+    }
 
     function escapeHtml(s) {
       return String(s).replace(/[&<>"']/g, (c) => (
@@ -351,6 +370,9 @@
         landing.classList.add("hidden");
         session.classList.remove("hidden");
         feed.innerHTML = "";
+        feed.classList.add("hidden");
+        hintTarget.textContent = targetLabel;
+        feedHint.classList.remove("hidden");
         targetBadge.textContent = `→ ${targetLabel}`;
         setStatus("Connecting…");
 
@@ -368,8 +390,7 @@
           catch (err) { console.warn("[ws] parse error:", err); }
         };
         ws.onclose = (e) => {
-          setStatus("Disconnected", false);
-          if (!e.wasClean) addSource("Connection lost.");
+          setStatus(e.wasClean ? "Disconnected" : "Connection lost", false);
         };
         ws.onerror = () => setStatus("Connection error", false);
       } catch (err) {
@@ -396,10 +417,11 @@
           if (msg.audio) playAudioChunk(msg.audio);
           return;
 
-        // Source-language transcript of what the speaker said.
+        // The speaker finished an utterance. We don't render the source
+        // text — it's only a boundary signal to close the current
+        // translation line so the next one starts fresh.
         case "transcript.committed":
-          if (msg.transcript) addSource(msg.transcript);
-          finalizeXlt(); // a new utterance heard → close the prior translation
+          finalizeXlt();
           return;
 
         // Streaming translated text (the words the model is speaking).

--- a/examples/live-translate/server.ts
+++ b/examples/live-translate/server.ts
@@ -1,0 +1,214 @@
+/**
+ * Live Translate — browser-direct real-time speech-to-speech translation.
+ *
+ * Flow:
+ *   Browser ↔ Opper (direct WS, carries the live audio)
+ *   Browser ↔ Node REST (mints the ticket only)
+ *
+ * Why a ticket:
+ *   - Browsers cannot set an Authorization header on `new WebSocket(...)`.
+ *   - The Node server authenticates with the real OPPER_API_KEY at
+ *     POST /v3/realtime-sessions, binds the model + target language onto a
+ *     single-use `client_secret`, and the browser opens
+ *     `wss://api.opper.ai/v3/realtime` directly with the ticket in the
+ *     `Sec-WebSocket-Protocol: opper-ticket.<secret>` subprotocol header.
+ *   - The API key never reaches the browser.
+ *
+ * Unlike a chat agent, the translation model has no tools and no system
+ * prompt — it just listens in any language and speaks the bound target
+ * language. So this server is tiny: one mint endpoint, nothing on the WS
+ * path.
+ *
+ * Model: gemini/gemini-3.5-live-translate-preview. Source language is
+ * auto-detected across 70+ languages; only the TARGET is configured, and
+ * we bind it onto the ticket so a leaked ticket can't repurpose the
+ * session into a different language.
+ */
+
+import express from "express";
+import { createServer as createNetServer } from "net";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const PREFERRED_PORT = parseInt(process.env.PORT || "3000");
+const OPPER_API_KEY = process.env.OPPER_API_KEY;
+// Default to production. The Live Translate model must be available on the
+// target deployment — point OPPER_BASE_URL at a local stack running the
+// branch that adds gemini-3.5-live-translate-preview if it isn't in prod yet.
+const OPPER_BASE_URL = process.env.OPPER_BASE_URL || "https://api.opper.ai";
+const PUBLIC_WS_BASE =
+  process.env.OPPER_WS_BASE ||
+  OPPER_BASE_URL.replace(/^http/, "ws").replace(/\/$/, "");
+
+const MODEL_ID = "gemini/gemini-3.5-live-translate-preview";
+
+// The languages the browser may pick as a translation target. The browser
+// POSTs its choice; this server validates against the list before binding
+// it onto the ticket. BCP-47 codes the Live Translate model accepts.
+// This is the policy boundary — the browser cannot translate into a
+// language not on this menu. (The model supports 70+; this is a curated
+// subset for the demo dropdown.)
+type Language = { code: string; label: string };
+const TARGET_LANGUAGES: Language[] = [
+  { code: "en", label: "English" },
+  { code: "es", label: "Spanish" },
+  { code: "fr", label: "French" },
+  { code: "de", label: "German" },
+  { code: "it", label: "Italian" },
+  { code: "pt-BR", label: "Portuguese (Brazil)" },
+  { code: "nl", label: "Dutch" },
+  { code: "sv", label: "Swedish" },
+  { code: "pl", label: "Polish" },
+  { code: "tr", label: "Turkish" },
+  { code: "ar", label: "Arabic" },
+  { code: "hi", label: "Hindi" },
+  { code: "ja", label: "Japanese" },
+  { code: "ko", label: "Korean" },
+  { code: "zh-Hans", label: "Chinese (Simplified)" },
+];
+const DEFAULT_TARGET = "es";
+
+if (!OPPER_API_KEY) {
+  console.error("  OPPER_API_KEY is required");
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Ticket mint. The CRITICAL part is `config`: every field we set is bound
+// to the ticket, so the browser cannot override it on session.start. A
+// leaked ticket can only run the exact translation session we authorized —
+// it cannot switch models or change the target language.
+// ---------------------------------------------------------------------------
+
+async function mintTranslateTicket(targetLanguage: string): Promise<{
+  clientSecret: string;
+  expiresAt: string;
+  wsBaseUrl: string;
+}> {
+  const config = {
+    model: MODEL_ID,
+    translation_target_language: targetLanguage,
+    // Captions for both sides of the conversation: the source-language
+    // transcript of what was said, and the translated text the model
+    // speaks. Both fold into the audio token meter (no extra charge on
+    // Gemini), and give the UI something to render alongside the audio.
+    input_transcription: true,
+    output_transcription: true,
+  };
+
+  const resp = await fetch(`${OPPER_BASE_URL}/v3/realtime-sessions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPPER_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    // Lock the model and the target language so the browser can't change
+    // them. translation_target_language is force-applied via locked_fields
+    // so even an empty/edited browser value can't unset it.
+    body: JSON.stringify({
+      config,
+      locked_fields: ["model", "translation_target_language"],
+      ttl_seconds: 60,
+    }),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`mint failed (${resp.status}): ${text}`);
+  }
+
+  const data = (await resp.json()) as {
+    client_secret: string;
+    expires_at: string;
+    ws_url?: string;
+  };
+  // Hand the browser a clean WS origin; it carries the ticket in the
+  // subprotocol header, not the URL, so the secret stays out of access
+  // logs and browser history.
+  let wsBaseUrl = data.ws_url || `${PUBLIC_WS_BASE}/v3/realtime`;
+  wsBaseUrl = wsBaseUrl.replace(/[?&]ticket=[^&]*/g, "").replace(/[?&]$/, "");
+  return {
+    clientSecret: data.client_secret,
+    expiresAt: data.expires_at,
+    wsBaseUrl,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Find an available port
+// ---------------------------------------------------------------------------
+
+async function findPort(start: number, end = start + 20): Promise<number> {
+  for (let port = start; port <= end; port++) {
+    const ok = await new Promise<boolean>((resolve) => {
+      const s = createNetServer();
+      s.once("error", () => resolve(false));
+      s.listen(port, () => s.close(() => resolve(true)));
+    });
+    if (ok) return port;
+  }
+  return start;
+}
+
+// ---------------------------------------------------------------------------
+// Express
+// ---------------------------------------------------------------------------
+
+const app = express();
+app.use(express.json({ limit: "256kb" }));
+app.use(express.static(join(__dirname, "public")));
+
+// Expose the curated language menu so the landing page can render the
+// dropdown. The browser cannot add to this list — anything it posts back
+// is validated against TARGET_LANGUAGES before the ticket is minted.
+app.get("/api/config", (_req, res) => {
+  res.json({ languages: TARGET_LANGUAGES, defaultTarget: DEFAULT_TARGET });
+});
+
+// Mint endpoint. Browser POSTs its chosen target language; we validate
+// against the allowlist and only then mint a ticket bound to that target.
+app.post("/api/realtime/session", async (req, res) => {
+  try {
+    const requested = (req.body?.target as string | undefined) || DEFAULT_TARGET;
+    const lang = TARGET_LANGUAGES.find((l) => l.code === requested);
+    if (!lang) {
+      return res.status(400).json({
+        error: `target "${requested}" not in allowlist`,
+        allowed: TARGET_LANGUAGES.map((l) => l.code),
+      });
+    }
+
+    const ticket = await mintTranslateTicket(lang.code);
+    console.log(`  Minted translate ticket: target=${lang.code} (${lang.label}), expires ${ticket.expiresAt}`);
+    res.json({ ...ticket, target: lang.code, targetLabel: lang.label });
+  } catch (err) {
+    console.error("  Mint failed:", err);
+    res.status(500).json({ error: String(err) });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Start
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log("\n  🗣️  Live Translate\n");
+  const port = await findPort(PREFERRED_PORT);
+  app.listen(port, () => {
+    console.log(`  Ready at http://localhost:${port}`);
+    console.log(`  Model:       ${MODEL_ID}`);
+    console.log(`  Mint:        POST /api/realtime/session`);
+    console.log(`  Realtime WS: ${PUBLIC_WS_BASE}/v3/realtime  (browser-direct)\n`);
+  });
+}
+
+main().catch((err) => {
+  console.error("Startup failed:", err);
+  process.exit(1);
+});

--- a/examples/live-translate/tsconfig.json
+++ b/examples/live-translate/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## What

A new cookbook example: **real-time speech-to-speech translation** in the browser. You speak in any language; the model speaks it back in the language you pick — continuously, the way a human interpreter works. Powered by Opper's Realtime API and **Gemini 3.5 Live Translate** (`gemini/gemini-3.5-live-translate-preview`).

## Pattern (same as brainstorm-time)

- **Browser-direct WebSocket** authenticated with a single-use ephemeral ticket carried in the `Sec-WebSocket-Protocol: opper-ticket.<secret>` subprotocol — the API key never reaches the browser.
- **Pre-binding** — the model **and the target language** are locked onto the ticket at mint time via `locked_fields`. A leaked ticket can only run the exact translation authorized; it can't switch models or change the target language.
- The Node server is tiny: one mint endpoint, nothing on the audio path.

## What's new vs. a chat agent

- No tools, no system prompt — the model just listens in any language and speaks the bound target language.
- Source language is **auto-detected** across 70+ languages; only the target is configured.
- Live captions: source-language transcript of what was heard (`transcript.committed`) + streaming translated text (`text.delta`).

## Files

- `server.ts` — mint endpoint (binds model + `translation_target_language`), language allowlist, static serving
- `public/index.html` — translator UI (brainstorm-time theme), mic capture, translated-audio playback, captions
- `README.md`

## Notes

- Needs `gemini-3.5-live-translate-preview` on the target Opper deployment. README documents pointing `OPPER_BASE_URL` at a local stack if it isn't in prod yet.
- The translate model is continuous (no turn boundaries); the README calls out that captions are best-effort and the audio is the primary output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)