### PR TITLE
media-studio: video, audio, fal + Reve, dual image inputs

### DIFF
--- a/examples/media-studio/README.md
+++ b/examples/media-studio/README.md
@@ -2,14 +2,16 @@
 
 A click-first **media generation studio** built on Opper. Log in, pick what to make, pick a
 model, and get a great result on the happy path — "Advanced options" stay tucked away until
-you want them. Images and video today; structured to grow into audio next.
+you want them. Images, video, and speech today; one catalog drives them all.
 
 It showcases a lot of Opper in one small app:
 
 - **`/v3/images`** — synchronous image generation across many providers (OpenAI, Google,
-  xAI, Pruna, Black Forest Labs) from one catalog.
-- **`/v3/videos`** — asynchronous text/image-to-video (Alibaba HappyHorse, xAI, Pruna, Veo):
-  submit a job, poll, then play the clip inline.
+  xAI, Pruna, Black Forest Labs, fal.ai, Reve) from one catalog.
+- **`/v3/videos`** — asynchronous text/image-to-video (ByteDance Seedance, Alibaba HappyHorse,
+  xAI, Pruna, Veo): submit a job, poll, then play the clip inline.
+- **`/v3/audio/speech`** — synchronous text-to-speech (OpenAI, xAI, Google, ElevenLabs) with
+  voice / format / speed controls.
 - **`/v3/files`** — every result is stored, so it's reusable as a reference and shareable.
 - **`/v3/call`** with `output_schema` — the smart "intent bar" turns a sentence into
   prefilled settings (a structured-output demo).
@@ -75,10 +77,25 @@ account's API key. That also lets the gallery show each image's model and prompt
 
 ## The model catalog
 
-Everything the UI shows — the picker, the advanced drawer, the reference slots — is generated
+Everything the UI shows — the picker, the advanced drawer, the input slots — is generated
 from `catalog.ts`. Each entry declares its dimension style (pixel `size` vs `aspect` ratio),
-quality tiers, reference support, and a `happyPath` of great defaults. **Adding a model is a
+quality tiers, input support, and a `happyPath` of great defaults. **Adding a model is a
 data edit**, not a UI change.
+
+### Starting image vs. references
+
+Two kinds of image input are distinct fields on the API, and a model can take **both**:
+
+- **Starting image** (`image`) — the source the model works *from*: the picture to edit, or a
+  video's first frame (image-to-video). Single image.
+- **References** (`reference_images`) — subject/style guides the model is *influenced by*
+  without reproducing them as a frame. Up to several.
+
+A catalog entry opts into each slot independently (`supports.imageEdit` → starting image,
+`supports.referenceImages` → references for images; `video.inputKind` + `video.referenceImages`
+for video). Models that support both — e.g. GPT Image, the Gemini image models, Reve, Seedance,
+Veo — render both slots, so you can animate *this* frame while keeping *that* character
+consistent. The studio sends each filled slot as its own field.
 
 ## Video
 
@@ -90,19 +107,32 @@ video's per-model knobs (duration, resolution, aspect) aren't top-level fields �
 `aspectRatio`; HappyHorse wants `resolution: "720P"` uppercase). Each catalog entry's `video`
 block carries the right keys, and `happyPath` is the baseline `parameters` object.
 
-Image-to-video models reuse the reference-upload flow; ones that *require* a source image
-(e.g. HappyHorse i2v) gate Generate until you add one.
+Image-to-video models reuse the same input slots as images (starting image + references); ones
+that *require* a starting image (e.g. HappyHorse i2v) gate Generate until you add one.
 
-> The default video model (HappyHorse text-to-video) is live-verified. The other video entries
-> follow the model specs but aren't all individually verified — provider param casing is fiddly,
-> so check the server log if one fails (errors are relayed verbatim).
+> The default video model (HappyHorse text-to-video) and Seedance 2.0 image-to-video are
+> live-verified. The other video entries follow the model specs but aren't all individually
+> verified — provider param casing is fiddly, so check the server log if one fails (errors are
+> relayed verbatim).
 
-## Extending to audio
+## Audio
 
-The seams are in place: add `modality: "audio"` entries to `catalog.ts`, flip Audio to
-`live: true` in `public/app.js` (`MODALITIES`), and point Generate at `/v3/audio/speech`
-(synchronous, like images). The picker, advanced options, gallery, share, and delete are all
-modality-agnostic.
+Audio (text-to-speech) reuses the same catalog/picker/gallery shell as images — it's
+**synchronous**, like `/v3/images`. The prompt box becomes "the text to speak", the advanced
+panel offers **voice / format / speed** (from each model's `audio` config in `catalog.ts`), and
+`POST /v3/audio/speech` returns the clip, which plays inline and is stored to `/v3/files` so it
+lands in the gallery and shares like everything else. The intent bar is hidden here — speech
+text is literal, not a visual prompt to structure.
+
+Each `modality: "audio"` catalog entry declares its `voices`, `formats`, and whether it takes a
+`speed` knob; voice/format are validated server-side against the model. Providers that use
+account-scoped voice ids (ElevenLabs) omit `voices` and use the account default.
+
+## Extending to transcription (STT)
+
+The other half of audio — speech-to-text — is `POST /v3/audio/transcriptions` (audio in, text
+out). It inverts the prompt→media shell (you upload audio and get a transcript), so it'd be a
+small dedicated flow rather than another catalog entry. Not wired yet.
 
 ## Notes
 

--- a/examples/media-studio/catalog.ts
+++ b/examples/media-studio/catalog.ts
@@ -27,14 +27,22 @@ export type VideoConfig = {
   durations?: VideoControl<number>;
 };
 
+/** Text-to-speech config. The prompt is the text to speak; these drive the controls. */
+export type AudioConfig = {
+  voices?: string[]; // selectable named voices; omit when the provider uses account-scoped voice ids (sends the model default)
+  defaultVoice?: string; // preselected voice (must be in voices)
+  formats?: string[]; // selectable output formats; omit to use the model default
+  speed?: boolean; // expose a playback-speed control
+};
+
 export type ModelEntry = {
   id: string;
   label: string;
   provider: string;
-  modality: "image" | "video";
+  modality: "image" | "video" | "audio";
   blurb: string;
-  approxCost: number; // USD per image, or per-second/flat for video — for the picker
-  costUnit?: "image" | "second" | "clip"; // how approxCost reads (default: image)
+  approxCost: number; // USD per image, per-second/flat for video, per-1K-chars for audio — for the picker
+  costUnit?: "image" | "second" | "clip" | "1k"; // how approxCost reads (default: image)
   default?: boolean; // default *within its modality*
   // image
   dimension?: Dimension;
@@ -42,6 +50,8 @@ export type ModelEntry = {
   qualityDefault?: string;
   // video
   video?: VideoConfig;
+  // audio (TTS)
+  audio?: AudioConfig;
   // when a source/edit image is attached, route to this model id instead
   editModel?: string;
   supports: {
@@ -156,8 +166,107 @@ export const CATALOG: ModelEntry[] = [
     happyPath: { size: "1024x1024", n: 1 },
   },
 
+  {
+    id: "fal/flux-1-schnell",
+    label: "FLUX.1 [schnell]",
+    provider: "fal.ai",
+    modality: "image",
+    blurb: "Fastest, cheapest FLUX — sub-cent images in a blink.",
+    approxCost: 0.003,
+    dimension: {
+      kind: "size",
+      options: ["1024x1024", "1280x720", "720x1280", "1024x768", "768x1024", "1536x1024", "1024x1536"],
+      default: "1024x1024",
+    },
+    supports: { n: 1, seed: true },
+    happyPath: { size: "1024x1024", n: 1 },
+  },
+  {
+    id: "fal/recraft-v3",
+    label: "Recraft V3",
+    provider: "fal.ai",
+    modality: "image",
+    blurb: "Top-ranked text rendering, plus brand and vector styles.",
+    approxCost: 0.04,
+    dimension: {
+      kind: "size",
+      options: ["1024x1024", "1280x720", "720x1280", "1024x768", "768x1024", "1536x1024", "1024x1536"],
+      default: "1024x1024",
+    },
+    supports: { n: 1 },
+    happyPath: { size: "1024x1024", n: 1 },
+  },
+  {
+    id: "fal/ideogram-v3",
+    label: "Ideogram V3",
+    provider: "fal.ai",
+    modality: "image",
+    blurb: "Crisp text and design; the quality tier sets speed and price.",
+    approxCost: 0.06,
+    dimension: {
+      kind: "size",
+      options: ["1024x1024", "1280x720", "720x1280", "1024x768", "768x1024", "1536x1024", "1024x1536"],
+      default: "1024x1024",
+    },
+    qualities: ["low", "medium", "high"],
+    qualityDefault: "medium",
+    supports: { n: 1, seed: true },
+    happyPath: { size: "1024x1024", quality: "medium", n: 1 },
+  },
+  {
+    id: "fal/flux-kontext-pro",
+    label: "FLUX.1 Kontext [pro]",
+    provider: "fal.ai",
+    modality: "image",
+    blurb: "Instruction-based editing — add a source image and describe the change.",
+    approxCost: 0.04,
+    dimension: {
+      kind: "size",
+      options: ["1024x1024", "1280x720", "720x1280", "1024x768", "768x1024", "1536x1024", "1024x1536"],
+      default: "1024x1024",
+    },
+    supports: { imageEdit: true, n: 1, seed: true },
+    happyPath: { size: "1024x1024", n: 1 },
+  },
+  {
+    id: "reve/reve-image",
+    label: "Reve Image",
+    provider: "Reve.ai",
+    modality: "image",
+    blurb: "Strong prompt adherence and accurate typography. Create, edit, or remix from references.",
+    approxCost: 0.024,
+    dimension: {
+      kind: "aspect",
+      options: ["1:1", "16:9", "9:16", "3:2", "2:3", "4:3", "3:4"],
+      default: "1:1",
+    },
+    supports: { imageEdit: true, referenceImages: true, n: 1 },
+    happyPath: { aspect_ratio: "1:1", n: 1 },
+  },
+
   // ---- Video (async: POST /v3/videos → poll /v3/artifacts/{id}/status) ----
   // For video, happyPath is the `parameters` object; keys are provider-specific.
+  {
+    id: "deepinfra/ByteDance/Seedance-2.0",
+    label: "Seedance 2.0",
+    provider: "ByteDance",
+    modality: "video",
+    blurb:
+      "Cinematic clips up to 15s with native synced audio. Text-to-video, or add a starting image (i2v) and subject references.",
+    approxCost: 0.07,
+    costUnit: "second",
+    // One model id does it all: a starting image animates it (i2v), reference
+    // images keep a subject consistent, and neither is text-to-video (t2v).
+    supports: {},
+    video: {
+      inputKind: "both",
+      referenceImages: true,
+      resolutions: { key: "resolution", options: ["480p", "720p", "1080p"], default: "720p" },
+      aspectRatios: { key: "aspect_ratio", options: ["16:9", "9:16", "1:1", "4:3", "3:4", "21:9"], default: "16:9" },
+      durations: { key: "duration", options: [5, 8, 10, 15], default: 5 },
+    },
+    happyPath: { resolution: "720p", aspect_ratio: "16:9", duration: 5, generate_audio: true },
+  },
   {
     id: "alibaba:eu/happyhorse-1.0-t2v",
     label: "HappyHorse · Text→Video",
@@ -187,6 +296,23 @@ export const CATALOG: ModelEntry[] = [
     video: {
       inputKind: "i2v",
       requiresImage: true,
+      resolutions: { key: "resolution", options: ["720P", "1080P"], default: "720P" },
+      durations: { key: "duration", options: [3, 5, 8, 10], default: 5 },
+    },
+    happyPath: { resolution: "720P", duration: 5 },
+  },
+  {
+    id: "alibaba:eu/happyhorse-1.0-r2v",
+    label: "HappyHorse · Reference→Video",
+    provider: "Alibaba",
+    modality: "video",
+    blurb: "Generate a clip that keeps a subject from your reference images consistent, with audio.",
+    approxCost: 0.14,
+    costUnit: "second",
+    supports: {},
+    video: {
+      inputKind: "t2v", // no first frame; the subject comes from reference images
+      referenceImages: true,
       resolutions: { key: "resolution", options: ["720P", "1080P"], default: "720P" },
       durations: { key: "duration", options: [3, 5, 8, 10], default: 5 },
     },
@@ -242,6 +368,23 @@ export const CATALOG: ModelEntry[] = [
     happyPath: { resolution: "480p" },
   },
   {
+    id: "pruna/vace",
+    label: "Wan VACE",
+    provider: "Pruna",
+    modality: "video",
+    blurb: "Text-to-video guided by reference images — character animation and editing. Flat rate.",
+    approxCost: 0.1,
+    costUnit: "clip",
+    supports: {},
+    video: {
+      inputKind: "t2v",
+      referenceImages: true,
+      // VACE takes a WxH `size` (the '*' separator), not a resolution/aspect tier.
+      resolutions: { key: "size", options: ["832*480", "480*832", "1280*720", "720*1280"], default: "832*480" },
+    },
+    happyPath: { size: "832*480" },
+  },
+  {
     id: "vertexai/veo-3.1-generate-001",
     label: "Veo 3.1",
     provider: "Google",
@@ -276,6 +419,90 @@ export const CATALOG: ModelEntry[] = [
       durations: { key: "durationSeconds", options: [4, 6, 8], default: 4 },
     },
     happyPath: { resolution: "720p", aspectRatio: "16:9", durationSeconds: 4, generateAudio: true },
+  },
+
+  // ---- Audio / TTS (sync: POST /v3/audio/speech, like images) ----
+  // The prompt is the text to speak; happyPath carries voice/format/speed.
+  {
+    id: "openai/tts-1",
+    label: "OpenAI TTS-1",
+    provider: "OpenAI",
+    modality: "audio",
+    blurb: "Fast, natural speech with eleven expressive voices. The everyday default.",
+    approxCost: 0.015,
+    costUnit: "1k",
+    default: true,
+    supports: {},
+    audio: {
+      voices: ["alloy", "ash", "ballad", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer", "verse"],
+      defaultVoice: "alloy",
+      formats: ["mp3", "wav", "opus", "flac"],
+      speed: true,
+    },
+    happyPath: { voice: "alloy", format: "mp3", speed: 1 },
+  },
+  {
+    id: "openai/tts-1-hd",
+    label: "OpenAI TTS-1 HD",
+    provider: "OpenAI",
+    modality: "audio",
+    blurb: "Higher-fidelity OpenAI speech — same voices, crisper output.",
+    approxCost: 0.03,
+    costUnit: "1k",
+    supports: {},
+    audio: {
+      voices: ["alloy", "ash", "ballad", "coral", "echo", "fable", "onyx", "nova", "sage", "shimmer", "verse"],
+      defaultVoice: "nova",
+      formats: ["mp3", "wav", "opus", "flac"],
+      speed: true,
+    },
+    happyPath: { voice: "nova", format: "mp3", speed: 1 },
+  },
+  {
+    id: "xai/tts",
+    label: "Grok TTS",
+    provider: "xAI",
+    modality: "audio",
+    blurb: "xAI's expressive speech in five distinct voices.",
+    approxCost: 0.015,
+    costUnit: "1k",
+    supports: {},
+    audio: {
+      voices: ["eve", "ara", "leo", "rex", "sal"],
+      defaultVoice: "eve",
+      speed: true,
+    },
+    happyPath: { voice: "eve", speed: 1 },
+  },
+  {
+    id: "gemini/gemini-2.5-flash-preview-tts",
+    label: "Gemini 2.5 Flash TTS",
+    provider: "Google",
+    modality: "audio",
+    blurb: "Google's TTS with a large voice roster. Token-priced; outputs WAV.",
+    approxCost: 0.01,
+    costUnit: "1k",
+    supports: {},
+    audio: {
+      voices: ["Kore", "Puck", "Charon", "Zephyr", "Fenrir", "Leda", "Orus", "Aoede"],
+      defaultVoice: "Kore",
+    },
+    happyPath: { voice: "Kore", format: "wav" },
+  },
+  {
+    id: "elevenlabs/eleven_multilingual_v2",
+    label: "Eleven Multilingual v2",
+    provider: "ElevenLabs",
+    modality: "audio",
+    blurb: "Lifelike, emotive speech across 29 languages. Uses the account's default voice.",
+    approxCost: 0.1,
+    costUnit: "1k",
+    supports: {},
+    audio: {
+      formats: ["mp3", "wav", "opus", "pcm"],
+      speed: true,
+    },
+    happyPath: { format: "mp3", speed: 1 },
   },
 ];
 

--- a/examples/media-studio/catalog.ts
+++ b/examples/media-studio/catalog.ts
@@ -48,6 +48,9 @@ export type ModelEntry = {
   dimension?: Dimension;
   qualities?: string[];
   qualityDefault?: string;
+  // A numeric quality/effort knob forwarded under parameters[key] — e.g. Reve's
+  // test_time_scaling (higher = more compute/detail, billed proportionally).
+  effort?: { key: string; options: number[]; default: number };
   // video
   video?: VideoConfig;
   // audio (TTS)
@@ -240,6 +243,9 @@ export const CATALOG: ModelEntry[] = [
       options: ["1:1", "16:9", "9:16", "3:2", "2:3", "4:3", "3:4"],
       default: "1:1",
     },
+    // Reve's test_time_scaling: 1 = base, up to 5 = more effort/detail (billed
+    // proportionally). The provider accepts 1–15 but >5 rarely helps.
+    effort: { key: "test_time_scaling", options: [1, 2, 3, 4, 5], default: 1 },
     supports: { imageEdit: true, referenceImages: true, n: 1 },
     happyPath: { aspect_ratio: "1:1", n: 1 },
   },

--- a/examples/media-studio/public/app.js
+++ b/examples/media-studio/public/app.js
@@ -10,15 +10,14 @@ const state = {
   modality: "image", // which media type the picker is showing
   model: null, // selected ModelEntry
   options: {}, // image: top-level options; video: the `parameters` object
-  references: [], // [{ file_id, preview }]
+  inputs: {}, // { image: [{file_id, preview}], reference_images: [...] } — per input slot
   sessionCost: 0,
 };
 
-// Modalities. Audio is the next one to light up.
 const MODALITIES = [
   { id: "image", label: "Image", icon: "▣", live: true },
   { id: "video", label: "Video", icon: "▶", live: true },
-  { id: "audio", label: "Audio", icon: "♪", live: false },
+  { id: "audio", label: "Audio", icon: "♪", live: true },
 ];
 
 // ---------------------------------------------------------------------------
@@ -133,29 +132,18 @@ function closePicker() {
   pickerOnPick = null;
 }
 
-/** Add an image (uploaded or picked) to the current model's input, respecting its max. */
-function addReference(ref) {
-  const max = maxRefs(state.model);
-  if (max === 0) return;
-  if (state.references.length >= max) state.references = state.references.slice(0, max - 1);
-  state.references.push(ref);
-  renderReferenceZone();
-  updateGenerateEnabled();
-}
-
-/** Animate an image into a video: switch to an image-to-video model with it as the source. */
+/** Animate an image into a video: switch to an image-to-video model with it as the starting frame. */
 function animateImage(fileId, src) {
   const i2v = state.catalog.find((m) => m.modality === "video" && m.video && m.video.inputKind !== "t2v");
   if (!i2v) return toast("No image-to-video model available.", true);
   state.modality = "video";
   renderModalities();
   renderModels();
-  selectModel(i2v.id);
-  state.references = [{ file_id: fileId, preview: src }];
-  renderReferenceZone();
-  updateGenerateEnabled();
+  selectModel(i2v.id); // clears state.inputs
+  const slot = inputSlots(i2v).find((s) => s.field === "image");
+  if (slot) addInput("image", slot.max, { file_id: fileId, preview: src });
   switchView("studio");
-  toast(`Source image set on ${i2v.label} — adjust options and Generate.`);
+  toast(`Starting image set on ${i2v.label} — adjust options and Generate.`);
 }
 
 // ---------------------------------------------------------------------------
@@ -197,10 +185,10 @@ function applyIntentPatch(p) {
   if (p.prompt) $("#prompt").value = p.prompt;
 
   const m = state.model;
-  if (p.aspect_ratio && m.dimension.kind === "aspect" && m.dimension.options.includes(p.aspect_ratio)) {
+  if (p.aspect_ratio && m.dimension?.kind === "aspect" && m.dimension.options.includes(p.aspect_ratio)) {
     state.options.aspect_ratio = p.aspect_ratio;
   }
-  if (p.size && m.dimension.kind === "size" && m.dimension.options.includes(p.size)) {
+  if (p.size && m.dimension?.kind === "size" && m.dimension.options.includes(p.size)) {
     state.options.size = p.size;
   }
   if (p.quality && m.qualities?.includes(p.quality)) state.options.quality = p.quality;
@@ -246,24 +234,28 @@ function galleryCard(item) {
   const fileId = item.file_id;
   const src = `/s/${fileId}`;
   const isVideo = item.kind === "video";
+  const isAudio = item.kind === "audio";
+  const isImage = !isVideo && !isAudio;
   const card = document.createElement("div");
   card.className = "result-card";
-  const media = isVideo
-    ? `<video src="${src}" controls playsinline preload="metadata"></video>`
-    : `<img loading="lazy" src="${src}" alt="${esc(item.prompt || "saved creation")}"/>`;
+  const body = isVideo
+    ? `<div class="img-wrap"><video src="${src}" controls playsinline preload="metadata"></video></div>`
+    : isAudio
+      ? `<div class="audio-wrap"><span class="audio-glyph">♪</span><audio controls src="${src}"></audio></div>`
+      : `<div class="img-wrap"><img loading="lazy" src="${src}" alt="${esc(item.prompt || "saved creation")}"/></div>`;
   card.innerHTML = `
-    <div class="img-wrap">${media}</div>
+    ${body}
     <div class="result-meta">
       <span class="rm-cost" title="${esc(item.prompt || "")}">${esc(item.model || "")}</span>
       <div class="result-actions">
-        ${isVideo ? "" : '<button class="icon-btn" data-act="remix">⇄ Remix</button>'}
-        ${isVideo ? "" : '<button class="icon-btn" data-act="animate">🎬 Video</button>'}
+        ${isImage ? '<button class="icon-btn" data-act="remix">⇄ Remix</button>' : ""}
+        ${isImage ? '<button class="icon-btn" data-act="animate">🎬 Video</button>' : ""}
         <button class="icon-btn" data-act="share">Share</button>
         <button class="icon-btn" data-act="download">Download</button>
         <button class="icon-btn" data-act="delete" title="Delete file">🗑</button>
       </div>
     </div>`;
-  if (!isVideo) {
+  if (isImage) {
     card.querySelector("img").addEventListener("click", () => openLightbox(src));
     card.querySelector('[data-act="remix"]').addEventListener("click", () => {
       remixFromResult({ file_id: fileId }, src);
@@ -273,7 +265,9 @@ function galleryCard(item) {
   }
   card.querySelector('[data-act="share"]').addEventListener("click", () => copyShareLink(fileId));
   card.querySelector('[data-act="download"]').addEventListener("click", () =>
-    downloadImage(src, { file_id: fileId, mime_type: isVideo ? "video/mp4" : item.mime_type }),
+    isAudio
+      ? downloadAudio(src, { file_id: fileId, mime_type: item.mime_type })
+      : downloadImage(src, { file_id: fileId, mime_type: isVideo ? "video/mp4" : item.mime_type }),
   );
   wireDelete(card.querySelector('[data-act="delete"]'), fileId, card);
   return card;
@@ -345,7 +339,7 @@ function renderModalities() {
 function switchModality(modality) {
   if (modality === state.modality) return;
   state.modality = modality;
-  state.references = [];
+  state.inputs = {};
   renderModalities();
   renderModels();
   selectModel(defaultModelFor(modality).id);
@@ -353,7 +347,8 @@ function switchModality(modality) {
 
 function costLabel(m) {
   const n = m.approxCost.toFixed(m.approxCost < 0.01 ? 3 : 2);
-  const unit = m.costUnit === "second" ? "/s" : m.costUnit === "clip" ? "/clip" : "";
+  const unit =
+    m.costUnit === "second" ? "/s" : m.costUnit === "clip" ? "/clip" : m.costUnit === "1k" ? "/1K" : "";
   return `~$${n}${unit}`;
 }
 
@@ -384,55 +379,100 @@ function selectModel(id) {
   if (!model) return;
   state.model = model;
   state.options = { ...model.happyPath };
+  state.inputs = {};
   document.querySelectorAll(".model-card").forEach((c) => c.classList.toggle("active", c.dataset.id === id));
   $("#advanced-toggle").hidden = false;
+  updateComposerForModality();
   renderAdvanced();
   renderReferenceZone();
   updateGenerateEnabled();
+}
+
+// The intent bar structures visual prompts; for speech the prompt is the literal
+// text to speak, so hide it and relabel the box.
+function updateComposerForModality() {
+  const mod = state.model?.modality;
+  $("#intent-bar").hidden = mod === "audio";
+  $("#prompt").placeholder =
+    mod === "audio" ? "The text to speak…" : "A prompt… or use the smart bar above to fill everything in.";
 }
 
 // ---------------------------------------------------------------------------
 // Reference media — upload to /v3/files, reuse as reference / edit source
 // ---------------------------------------------------------------------------
 
-// What input images (if any) the selected model takes, and how they're sent.
-function inputSpec(m) {
-  if (!m) return { max: 0 };
+// The input-image slots the selected model accepts. A model can offer BOTH a
+// "starting image" (→ `image`: the source to edit, or a video's first frame) and
+// "references" (→ `reference_images`: subject/style guides) — the API treats them
+// as distinct fields, so we render a slot for each. Order: starting image first.
+function inputSlots(m) {
+  if (!m) return [];
   if (m.modality === "image") {
-    if (m.supports.referenceImages) return { max: 8, field: "reference_images", noun: "reference" };
-    if (m.supports.imageEdit) return { max: 1, field: "image", noun: "image to edit" };
-    return { max: 0 };
+    const slots = [];
+    if (m.supports.imageEdit) slots.push({ field: "image", noun: "starting image", max: 1 });
+    if (m.supports.referenceImages) slots.push({ field: "reference_images", noun: "reference", max: 8 });
+    return slots;
   }
-  // video
-  const v = m.video || {};
-  if (v.referenceImages) return { max: 3, field: "reference_images", noun: "reference" };
-  if (v.inputKind === "i2v" || v.inputKind === "both") {
-    return { max: 1, field: "image", noun: "source image", required: !!v.requiresImage };
+  if (m.modality === "video") {
+    const v = m.video || {};
+    const slots = [];
+    if (v.inputKind === "i2v" || v.inputKind === "both")
+      slots.push({ field: "image", noun: "starting image", max: 1, required: !!v.requiresImage });
+    if (v.referenceImages) slots.push({ field: "reference_images", noun: "reference", max: 3 });
+    return slots;
   }
-  return { max: 0 };
+  return []; // audio takes no input image
 }
 
-function maxRefs(m) {
-  return inputSpec(m).max;
+function slotItems(field) {
+  return state.inputs[field] || (state.inputs[field] = []);
+}
+
+/** Add an image (uploaded or picked) to a slot, respecting its max (max 1 replaces). */
+function addInput(field, max, ref) {
+  const items = slotItems(field);
+  if (max === 1) items.length = 0;
+  else if (items.length >= max) items.shift();
+  items.push(ref);
+  renderReferenceZone();
+  updateGenerateEnabled();
 }
 
 function renderReferenceZone() {
   const zone = $("#reference-zone");
-  const spec = inputSpec(state.model);
-  if (spec.max === 0) {
+  const slots = inputSlots(state.model);
+  // Drop any stored inputs the current model doesn't accept.
+  for (const f of Object.keys(state.inputs)) {
+    if (!slots.some((s) => s.field === f)) delete state.inputs[f];
+  }
+  if (!slots.length) {
     zone.hidden = true;
-    state.references = [];
     return;
   }
   zone.hidden = false;
-  if (state.references.length > spec.max) state.references = state.references.slice(0, spec.max);
+  zone.replaceChildren(...slots.map(renderSlot));
+}
 
-  const thumbs = state.references.map((ref, i) => {
+function renderSlot(slot) {
+  const items = slotItems(slot.field);
+  if (items.length > slot.max) items.length = slot.max;
+
+  const group = document.createElement("div");
+  group.className = "input-slot";
+  const need = slot.required ? " (required)" : "";
+  const labelText = slot.field === "image" ? `Starting image${need}` : `References${need}`;
+  const lab = document.createElement("div");
+  lab.className = "input-slot-label";
+  lab.textContent = labelText;
+  const row = document.createElement("div");
+  row.className = "reference-row";
+
+  const thumbs = items.map((ref, i) => {
     const t = document.createElement("div");
     t.className = "ref-thumb";
-    t.innerHTML = `<img src="${ref.preview}" alt="reference"/><button class="ref-x" title="Remove">×</button>`;
+    t.innerHTML = `<img src="${ref.preview}" alt="${esc(slot.noun)}"/><button class="ref-x" title="Remove">×</button>`;
     t.querySelector(".ref-x").addEventListener("click", () => {
-      state.references.splice(i, 1);
+      items.splice(i, 1);
       renderReferenceZone();
       updateGenerateEnabled();
     });
@@ -441,22 +481,23 @@ function renderReferenceZone() {
 
   const addBtn = document.createElement("label");
   addBtn.className = "ref-add";
-  const need = spec.required ? " (required)" : "";
-  addBtn.innerHTML = `+ Add ${spec.noun}${need}<input type="file" accept="image/*" hidden ${spec.max > 1 ? "multiple" : ""}/>`;
-  addBtn.querySelector("input").addEventListener("change", (e) => onPickFiles(e.target.files));
+  addBtn.innerHTML = `+ Add ${esc(slot.noun)}<input type="file" accept="image/*" hidden ${slot.max > 1 ? "multiple" : ""}/>`;
+  addBtn.querySelector("input").addEventListener("change", (e) => onPickFiles(e.target.files, slot));
 
   const pickBtn = document.createElement("button");
   pickBtn.className = "ref-pick";
   pickBtn.textContent = "Choose from gallery";
-  pickBtn.addEventListener("click", () => openPicker(addReference));
+  pickBtn.addEventListener("click", () => openPicker((ref) => addInput(slot.field, slot.max, ref)));
 
-  const controls = state.references.length >= spec.max ? [] : [addBtn, pickBtn];
-  zone.replaceChildren(...thumbs, ...controls);
+  const controls = items.length >= slot.max ? [] : [addBtn, pickBtn];
+  row.replaceChildren(...thumbs, ...controls);
+  group.append(lab, row);
+  return group;
 }
 
-async function onPickFiles(fileList) {
-  const max = maxRefs(state.model);
-  const files = [...fileList].slice(0, max - state.references.length);
+async function onPickFiles(fileList, slot) {
+  const items = slotItems(slot.field);
+  const files = [...fileList].slice(0, slot.max - items.length);
   for (const file of files) {
     const preview = URL.createObjectURL(file);
     try {
@@ -468,9 +509,7 @@ async function onPickFiles(fileList) {
         handleApiError(res.status, data);
         continue;
       }
-      state.references.push({ file_id: data.id, preview });
-      renderReferenceZone();
-      updateGenerateEnabled();
+      addInput(slot.field, slot.max, { file_id: data.id, preview });
     } catch (err) {
       toast("Upload failed: " + err.message, true);
     }
@@ -479,15 +518,14 @@ async function onPickFiles(fileList) {
 
 /** Remix: feed a generated result back in as a reference (no re-upload). */
 function remixFromResult(item, src) {
-  if (maxRefs(state.model) === 0) {
-    // Current model can't take references — switch to the capable default.
-    const capable = state.catalog.find((m) => m.supports.referenceImages) ?? state.model;
+  // Need a model with a references slot — switch to the capable default if not.
+  if (!inputSlots(state.model).some((s) => s.field === "reference_images")) {
+    const capable = state.catalog.find((m) => m.modality === "image" && m.supports.referenceImages) ?? state.model;
     selectModel(capable.id);
   }
-  const max = maxRefs(state.model);
-  if (state.references.length >= max) state.references = state.references.slice(0, max - 1);
-  state.references.push({ file_id: item.file_id, preview: src });
-  renderReferenceZone();
+  const slot = inputSlots(state.model).find((s) => s.field === "reference_images");
+  if (!slot) return;
+  addInput("reference_images", slot.max, { file_id: item.file_id, preview: src });
   $("#prompt").focus();
   toast("Added as reference — tweak the prompt and generate.");
 }
@@ -506,6 +544,7 @@ function toggleAdvanced() {
 function renderAdvanced() {
   const m = state.model;
   if (m.modality === "video") return renderVideoAdvanced(m);
+  if (m.modality === "audio") return renderAudioAdvanced(m);
 
   const panel = $("#advanced-panel");
   const fields = [];
@@ -587,6 +626,42 @@ function renderVideoAdvanced(m) {
   panel.replaceChildren(...fields);
 }
 
+// Audio advanced options — voice / format / speed, from the model's audio config.
+// Each control writes into state.options (the top-level speech params).
+function renderAudioAdvanced(m) {
+  const panel = $("#advanced-panel");
+  const a = m.audio || {};
+  const fields = [];
+  if (a.voices?.length) {
+    fields.push(
+      fieldChips("Voice", a.voices, state.options.voice ?? a.defaultVoice, (v) => {
+        state.options.voice = v;
+      }),
+    );
+  }
+  if (a.formats?.length) {
+    fields.push(
+      fieldChips("Format", a.formats, state.options.format, (v) => {
+        state.options.format = v;
+      }),
+    );
+  }
+  if (a.speed) {
+    fields.push(
+      fieldChips(
+        "Speed",
+        [0.5, 0.75, 1, 1.25, 1.5, 2],
+        state.options.speed ?? 1,
+        (v) => {
+          state.options.speed = v;
+        },
+        (n) => `${n}×`,
+      ),
+    );
+  }
+  panel.replaceChildren(...fields);
+}
+
 function fieldChips(label, options, current, onChange, fmt) {
   const wrap = document.createElement("div");
   wrap.className = "field";
@@ -631,25 +706,29 @@ function fieldNumber(label, min, max, value, onChange) {
 // ---------------------------------------------------------------------------
 
 function updateGenerateEnabled() {
-  const spec = inputSpec(state.model);
-  const needsImage = spec.required && state.references.length === 0;
-  const ready = Boolean(state.model && $("#prompt").value.trim()) && !needsImage;
+  const missingRequired = inputSlots(state.model).some(
+    (s) => s.required && slotItems(s.field).length === 0,
+  );
+  const ready = Boolean(state.model && $("#prompt").value.trim()) && !missingRequired;
   $("#generate-btn").disabled = !ready;
 }
 
-// Attach any uploaded input images to a payload per the model's input spec.
+// Attach any uploaded input images to a payload, one field per filled slot:
+// `image` takes a single starting image; `reference_images` takes the list.
 function attachInputs(payload) {
-  if (!state.references.length) return;
-  const ids = state.references.map((r) => r.file_id);
-  const spec = inputSpec(state.model);
-  if (spec.field === "reference_images") payload.reference_images = ids;
-  else if (spec.field === "image") payload.image = ids[0];
+  for (const slot of inputSlots(state.model)) {
+    const ids = slotItems(slot.field).map((r) => r.file_id);
+    if (!ids.length) continue;
+    if (slot.field === "image") payload.image = ids[0];
+    else payload[slot.field] = ids;
+  }
 }
 
 async function generate() {
   const prompt = $("#prompt").value.trim();
   if (!state.model || !prompt) return;
   if (state.model.modality === "video") return generateVideo(prompt);
+  if (state.model.modality === "audio") return generateAudio(prompt);
 
   $("#empty-state").hidden = true;
   const card = addLoadingCard();
@@ -765,6 +844,93 @@ function fillVideoCard(card, data, prompt, model) {
   const shareBtn = card.querySelector('[data-act="share"]');
   if (data.file_id) shareBtn.addEventListener("click", () => copyShareLink(data.file_id));
   else shareBtn.remove();
+}
+
+// ---------------------------------------------------------------------------
+// Audio — synchronous TTS, like images: one request, one clip back
+// ---------------------------------------------------------------------------
+
+async function generateAudio(text) {
+  $("#empty-state").hidden = true;
+  const card = addLoadingCard();
+  setGenerating(true);
+
+  const o = state.options;
+  const payload = { model: state.model.id, input: text };
+  if (o.voice) payload.voice = o.voice;
+  if (o.format) payload.format = o.format;
+  if (typeof o.speed === "number" && o.speed !== 1) payload.speed = o.speed;
+
+  try {
+    const res = await fetch("/api/speech", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      clearCard(card);
+      handleApiError(res.status, data);
+      return;
+    }
+    fillAudioCard(card, data, text);
+    if (data.usage?.cost) bumpCost(data.usage.cost);
+  } catch (err) {
+    clearCard(card);
+    toast("Network error: " + err.message, true);
+  } finally {
+    setGenerating(false);
+  }
+}
+
+function fillAudioCard(card, data, text) {
+  clearInterval(card._timer);
+  const audio = data.audio || {};
+  const src = audioSrc(audio);
+  const cost = data.usage?.cost ? `$${data.usage.cost.toFixed(3)}` : "";
+  card.classList.remove("loading");
+  card.innerHTML = `
+    <div class="audio-wrap"><span class="audio-glyph">♪</span><audio controls src="${src}"></audio></div>
+    <div class="result-meta">
+      <span class="rm-cost" title="${esc(text)}">${esc(state.model.label)}${cost ? " · " + cost : ""}</span>
+      <div class="result-actions">
+        <button class="icon-btn" data-act="share">Share</button>
+        <button class="icon-btn" data-act="download">Download</button>
+      </div>
+    </div>`;
+  card.querySelector('[data-act="download"]').addEventListener("click", () =>
+    downloadAudio(src, { file_id: audio.file_id, mime_type: audio.mime_type }),
+  );
+  const shareBtn = card.querySelector('[data-act="share"]');
+  if (audio.file_id) shareBtn.addEventListener("click", () => copyShareLink(audio.file_id));
+  else shareBtn.remove();
+}
+
+function audioSrc(audio) {
+  if (audio.url) return audio.url;
+  if (audio.file_id) return `/s/${audio.file_id}`;
+  if (audio.b64_json) return `data:${audio.mime_type || "audio/mpeg"};base64,${audio.b64_json}`;
+  return "";
+}
+
+function downloadAudio(src, item) {
+  const m = item.mime_type || "audio/mpeg";
+  const ext = m.includes("wav")
+    ? ".wav"
+    : m.includes("flac")
+      ? ".flac"
+      : m.includes("opus") || m.includes("ogg")
+        ? ".opus"
+        : m.includes("aac")
+          ? ".aac"
+          : m.includes("pcm")
+            ? ".pcm"
+            : ".mp3";
+  const a = document.createElement("a");
+  a.href = src;
+  a.download = (item.file_id || "speech") + ext;
+  a.target = "_blank";
+  a.click();
 }
 
 // ---------------------------------------------------------------------------

--- a/examples/media-studio/public/app.js
+++ b/examples/media-studio/public/app.js
@@ -577,6 +577,17 @@ function renderAdvanced() {
     );
   }
 
+  // Quality/effort scale (e.g. Reve test_time_scaling) — forwarded via parameters.
+  // Higher = more compute/detail and proportionally more credits.
+  if (m.effort) {
+    const cur = state.options.parameters?.[m.effort.key] ?? m.effort.default;
+    fields.push(
+      fieldChips("Quality (1–5, higher costs more)", m.effort.options, cur, (v) => {
+        state.options.parameters = { ...(state.options.parameters || {}), [m.effort.key]: v };
+      }),
+    );
+  }
+
   // Number of images.
   if ((m.supports.n ?? 1) > 1) {
     fields.push(

--- a/examples/media-studio/public/app.js
+++ b/examples/media-studio/public/app.js
@@ -460,10 +460,20 @@ function renderSlot(slot) {
   const group = document.createElement("div");
   group.className = "input-slot";
   const need = slot.required ? " (required)" : "";
-  const labelText = slot.field === "image" ? `Starting image${need}` : `References${need}`;
+  const isImg = slot.field === "image";
+  const isVideo = state.model?.modality === "video";
+  const title = (isImg ? "Starting image" : "References") + need;
+  // The distinction is fuzzy across image models, so spell out what each does.
+  const hint = isImg
+    ? isVideo
+      ? "first frame to animate"
+      : "edits this image"
+    : isVideo
+      ? "keeps this subject consistent"
+      : "guides a new image";
   const lab = document.createElement("div");
   lab.className = "input-slot-label";
-  lab.textContent = labelText;
+  lab.innerHTML = `${esc(title)} <span class="input-slot-hint">· ${esc(hint)}</span>`;
   const row = document.createElement("div");
   row.className = "reference-row";
 

--- a/examples/media-studio/public/styles.css
+++ b/examples/media-studio/public/styles.css
@@ -234,10 +234,12 @@ body {
   border-radius: var(--radius-sm);
   padding: 14px;
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
+  flex-direction: column;
+  gap: 14px;
 }
+.input-slot { display: flex; flex-direction: column; gap: 8px; }
+.input-slot-label { font-size: 12px; color: var(--faint); }
+.reference-row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
 
 .ref-thumb { position: relative; width: 64px; height: 64px; border-radius: 8px; overflow: hidden; border: 1px solid var(--border); }
 .ref-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
@@ -310,6 +312,9 @@ body {
 .result-card img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .result-card video { width: 100%; height: 100%; object-fit: cover; display: block; background: #000; }
 .result-card:not(.loading) img { cursor: zoom-in; }
+.result-card .audio-wrap { display: grid; place-items: center; gap: 12px; padding: 26px 14px; background: var(--bg-input); }
+.result-card .audio-glyph { font-size: 34px; line-height: 1; color: var(--faint); }
+.result-card .audio-wrap audio { width: 100%; height: 36px; }
 .result-card.loading .img-wrap { display: grid; place-items: center; gap: 10px; }
 .result-card.loading .elapsed { font-size: 12px; color: var(--faint); font-variant-numeric: tabular-nums; }
 .result-meta { padding: 10px 12px; display: flex; flex-direction: column; gap: 8px; }

--- a/examples/media-studio/public/styles.css
+++ b/examples/media-studio/public/styles.css
@@ -238,7 +238,8 @@ body {
   gap: 14px;
 }
 .input-slot { display: flex; flex-direction: column; gap: 8px; }
-.input-slot-label { font-size: 12px; color: var(--faint); }
+.input-slot-label { font-size: 12px; color: var(--muted); }
+.input-slot-hint { color: var(--faint); }
 .reference-row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
 
 .ref-thumb { position: relative; width: 64px; height: 64px; border-radius: 8px; overflow: hidden; border: 1px solid var(--border); }

--- a/examples/media-studio/server.ts
+++ b/examples/media-studio/server.ts
@@ -166,7 +166,7 @@ type Creation = {
   model: string;
   prompt: string;
   created: number;
-  kind: "image" | "video";
+  kind: "image" | "video" | "audio";
 };
 
 const DATA_DIR = join(__dirname, "data");
@@ -431,6 +431,57 @@ app.post("/api/generate", async (req, res) => {
     res.json(data);
   } catch (err: any) {
     console.error(`✗ images  ${body.model}  ${err?.message}`);
+    res.status(502).json({ code: "network", error: err?.message || "Failed to reach Opper." });
+  }
+});
+
+/** Generate speech (TTS) — proxy to POST /v3/audio/speech (synchronous, like images). */
+app.post("/api/speech", async (req, res) => {
+  const session = getSession(req);
+  if (!session) return res.status(401).json({ code: "disconnected", error: "Not logged in." });
+
+  const b = req.body ?? {};
+  if (!b.model || !b.input) {
+    return res.status(400).json({ code: "bad_request", error: "model and input are required." });
+  }
+
+  // Forward only the fields /v3/audio/speech understands; store by default so each
+  // clip comes back with a reusable file_id and a presigned url.
+  const body: Record<string, unknown> = { model: b.model, input: b.input, store: true };
+  if (b.voice) body.voice = b.voice;
+  if (b.format) body.format = b.format;
+  if (typeof b.speed === "number") body.speed = b.speed;
+  if (b.parameters && typeof b.parameters === "object") body.parameters = b.parameters;
+
+  const started = Date.now();
+  console.log(`→ speech  ${body.model}  "${String(b.input).slice(0, 50)}"`);
+  try {
+    const upstream = await opperFetch(session, "/v3/audio/speech", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!upstream.ok) {
+      console.warn(`✗ speech  ${body.model}  ${upstream.status}  (${Date.now() - started}ms)`);
+      return relayError(res, upstream);
+    }
+    const data = await upstream.json();
+    console.log(`✓ speech  ${body.model}  ${Date.now() - started}ms  $${data.usage?.cost ?? "?"}`);
+    if (data.audio?.file_id) {
+      addCreations([
+        {
+          account: accountId(session.apiKey),
+          file_id: data.audio.file_id as string,
+          model: String(body.model),
+          prompt: String(b.input),
+          created: Date.now(),
+          kind: "audio" as const,
+        },
+      ]);
+    }
+    res.json(data);
+  } catch (err: any) {
+    console.error(`✗ speech  ${body.model}  ${err?.message}`);
     res.status(502).json({ code: "network", error: err?.message || "Failed to reach Opper." });
   }
 });

--- a/examples/media-studio/server.ts
+++ b/examples/media-studio/server.ts
@@ -345,8 +345,21 @@ async function presignedUrl(session: Session, fileId: string): Promise<string | 
 app.get("/api/catalog", (_req, res) => res.json({ models: CATALOG }));
 
 /** Upload a reference image — proxy to POST /v3/files, returns a reusable file_id. */
-const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 20 * 1024 * 1024 } });
-app.post("/api/files", upload.single("file"), async (req, res) => {
+// Match the backend /v3/files cap (50 MB) so the limit doesn't bite earlier here.
+const MAX_UPLOAD_MB = 50;
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: MAX_UPLOAD_MB * 1024 * 1024 } });
+// Wrap multer so its errors (e.g. file too large) come back as clean JSON instead
+// of an unhandled stack trace + a non-JSON body the browser can't parse.
+const uploadFile = (req: any, res: any, next: any) =>
+  upload.single("file")(req, res, (err: any) => {
+    if (!err) return next();
+    const tooLarge = err instanceof multer.MulterError && err.code === "LIMIT_FILE_SIZE";
+    res.status(tooLarge ? 413 : 400).json({
+      code: "bad_request",
+      error: tooLarge ? `Image is too large (max ${MAX_UPLOAD_MB} MB).` : err.message || "Upload failed.",
+    });
+  });
+app.post("/api/files", uploadFile, async (req, res) => {
   const session = getSession(req);
   if (!session) return res.status(401).json({ code: "disconnected", error: "Not logged in." });
   if (!req.file) return res.status(400).json({ code: "bad_request", error: "No file uploaded." });


### PR DESCRIPTION
Extends the media-studio example: Seedance 2.0 video, audio/TTS (`/v3/audio/speech`), fal.ai + Reve image models, and separate starting-image vs reference-image input slots. All live-verified.