### PR TITLE
feat(live-translate): model picker — Gemini + OpenAI realtime translate

### DIFF
--- a/examples/live-translate/public/index.html
+++ b/examples/live-translate/public/index.html
@@ -109,6 +109,9 @@
         <button type="button" data-src="tab" class="src-opt field px-3 py-2.5 text-sm font-medium">▶️ Browser tab</button>
       </div>
 
+      <label class="block text-sm font-medium mb-2">Model</label>
+      <select id="modelSelect" class="field w-full px-3 py-2.5 mb-5"></select>
+
       <label class="block text-sm font-medium mb-2">Translate into</label>
       <select id="targetSelect" class="field w-full px-3 py-2.5 mb-5"></select>
 
@@ -169,6 +172,7 @@
     const landing = document.getElementById("landing");
     const session = document.getElementById("session");
     const targetSelect = document.getElementById("targetSelect");
+    const modelSelect = document.getElementById("modelSelect");
     const startBtn = document.getElementById("startBtn");
     const endBtn = document.getElementById("endBtn");
     const micBtn = document.getElementById("micBtn");
@@ -229,6 +233,12 @@
     (async () => {
       try {
         const cfg = await (await fetch("/api/config")).json();
+        for (const m of (cfg.models || [])) {
+          const o = document.createElement("option");
+          o.value = m.id; o.textContent = m.label;
+          if (m.id === cfg.defaultModel) o.selected = true;
+          modelSelect.appendChild(o);
+        }
         for (const l of cfg.languages) {
           const o = document.createElement("option");
           o.value = l.code; o.textContent = l.label;
@@ -481,6 +491,7 @@
 
     async function startSession() {
       const target = targetSelect.value;
+      const model = modelSelect.value;
       startBtn.disabled = true;
 
       // Acquire the capture stream INSIDE the click gesture. getDisplayMedia
@@ -503,7 +514,7 @@
         const resp = await fetch("/api/realtime/session", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ target }),
+          body: JSON.stringify({ target, model }),
         });
         if (!resp.ok) throw new Error((await resp.json()).error || resp.statusText);
         const ticket = await resp.json();

--- a/examples/live-translate/server.ts
+++ b/examples/live-translate/server.ts
@@ -46,7 +46,36 @@ const PUBLIC_WS_BASE =
   process.env.OPPER_WS_BASE ||
   OPPER_BASE_URL.replace(/^http/, "ws").replace(/\/$/, "");
 
-const MODEL_ID = "gemini/gemini-3.5-live-translate-preview";
+// The translation models the browser may pick. Like the language menu, this
+// is the policy boundary — the browser POSTs a choice, the server validates
+// it against this allowlist and binds it onto the ticket via locked_fields.
+// Both are speech-to-speech translation models that auto-detect the source
+// language; they differ on the wire (different providers) but the gateway
+// normalizes that, and the client reads each model's audio sample rate from
+// session.started, so no per-model client logic is needed.
+type Model = {
+  id: string;
+  label: string;
+  // Source-language captions. Free on Gemini (folds into the audio-token
+  // meter). On OpenAI realtime-translate, source transcripts need a separate
+  // gpt-realtime-whisper sub-mode (extra per-minute cost) and the gateway
+  // adapter doesn't surface source-transcript deltas yet, so we leave it off
+  // there — translated (target) captions still work via output_transcription.
+  inputTranscription: boolean;
+};
+const MODELS: Model[] = [
+  {
+    id: "gemini/gemini-3.5-live-translate-preview",
+    label: "Gemini 3.5 Live Translate",
+    inputTranscription: true,
+  },
+  {
+    id: "openai/gpt-realtime-translate",
+    label: "OpenAI GPT Realtime Translate",
+    inputTranscription: false,
+  },
+];
+const DEFAULT_MODEL = MODELS[0].id;
 
 // The languages the browser may pick as a translation target. The browser
 // POSTs its choice; this server validates against the list before binding
@@ -86,21 +115,21 @@ if (!OPPER_API_KEY) {
 // it cannot switch models or change the target language.
 // ---------------------------------------------------------------------------
 
-async function mintTranslateTicket(targetLanguage: string): Promise<{
+async function mintTranslateTicket(targetLanguage: string, model: Model): Promise<{
   clientSecret: string;
   expiresAt: string;
   wsBaseUrl: string;
 }> {
-  const config = {
-    model: MODEL_ID,
+  const config: Record<string, unknown> = {
+    model: model.id,
     translation_target_language: targetLanguage,
-    // Captions for both sides of the conversation: the source-language
-    // transcript of what was said, and the translated text the model
-    // speaks. Both fold into the audio token meter (no extra charge on
-    // Gemini), and give the UI something to render alongside the audio.
-    input_transcription: true,
+    // Translated (target-language) captions — what the model speaks. Drives
+    // the on-screen subtitles; supported on every translation model.
     output_transcription: true,
   };
+  // Source-language captions only when the model supports them cheaply
+  // (see Model.inputTranscription).
+  if (model.inputTranscription) config.input_transcription = true;
 
   const resp = await fetch(`${OPPER_BASE_URL}/v3/realtime-sessions`, {
     method: "POST",
@@ -168,7 +197,12 @@ app.use(express.static(join(__dirname, "public")));
 // dropdown. The browser cannot add to this list — anything it posts back
 // is validated against TARGET_LANGUAGES before the ticket is minted.
 app.get("/api/config", (_req, res) => {
-  res.json({ languages: TARGET_LANGUAGES, defaultTarget: DEFAULT_TARGET });
+  res.json({
+    languages: TARGET_LANGUAGES,
+    defaultTarget: DEFAULT_TARGET,
+    models: MODELS.map((m) => ({ id: m.id, label: m.label })),
+    defaultModel: DEFAULT_MODEL,
+  });
 });
 
 // Mint endpoint. Browser POSTs its chosen target language; we validate
@@ -184,9 +218,18 @@ app.post("/api/realtime/session", async (req, res) => {
       });
     }
 
-    const ticket = await mintTranslateTicket(lang.code);
-    console.log(`  Minted translate ticket: target=${lang.code} (${lang.label}), expires ${ticket.expiresAt}`);
-    res.json({ ...ticket, target: lang.code, targetLabel: lang.label });
+    const requestedModel = (req.body?.model as string | undefined) || DEFAULT_MODEL;
+    const model = MODELS.find((m) => m.id === requestedModel);
+    if (!model) {
+      return res.status(400).json({
+        error: `model "${requestedModel}" not in allowlist`,
+        allowed: MODELS.map((m) => m.id),
+      });
+    }
+
+    const ticket = await mintTranslateTicket(lang.code, model);
+    console.log(`  Minted translate ticket: model=${model.id}, target=${lang.code} (${lang.label}), expires ${ticket.expiresAt}`);
+    res.json({ ...ticket, target: lang.code, targetLabel: lang.label, model: model.id });
   } catch (err) {
     console.error("  Mint failed:", err);
     res.status(500).json({ error: String(err) });
@@ -202,7 +245,7 @@ async function main() {
   const port = await findPort(PREFERRED_PORT);
   app.listen(port, () => {
     console.log(`  Ready at http://localhost:${port}`);
-    console.log(`  Model:       ${MODEL_ID}`);
+    console.log(`  Models:      ${MODELS.map((m) => m.id).join(", ")}`);
     console.log(`  Mint:        POST /api/realtime/session`);
     console.log(`  Realtime WS: ${PUBLIC_WS_BASE}/v3/realtime  (browser-direct)\n`);
   });


### PR DESCRIPTION
## What

Adds a **Model** dropdown to the `live-translate` demo so you can switch between the two speech-to-speech translation models Opper exposes:

- `gemini/gemini-3.5-live-translate-preview`
- `openai/gpt-realtime-translate`

## How

- **Server** (`server.ts`): a `MODELS` allowlist mirrors the existing language allowlist as the policy boundary — the browser POSTs its choice, the server validates it against the list and binds it onto the ephemeral ticket via `locked_fields` (so a leaked ticket can't swap models). Per-model config: source-language captions (`input_transcription`) only where they're free (Gemini); translated captions (`output_transcription`) on both.
- **Client** (`public/index.html`): a model `<select>` populated from `/api/config`. **No per-model audio logic needed** — the client already reads each model's input/output sample rate from `session.started` (Gemini is 16 kHz-in / 24 kHz-out; OpenAI is 24 kHz both ways), so the gateway's framing flows through unchanged.

## Verified

Ran end-to-end against a local Opper stack with both models selected — translated audio + captions return correctly for each.

Pairs with the task-api PR that adds `openai/gpt-realtime-translate` (opper#3130).

🤖 Generated with [Claude Code](https://claude.com/claude-code)